### PR TITLE
Search Api must subscribe to MatchFound Events

### DIFF
--- a/app/SearchApi/SearchApi.Web.Test/Search/MatchFoundConsumerTest.cs
+++ b/app/SearchApi/SearchApi.Web.Test/Search/MatchFoundConsumerTest.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Linq;
+using System.Threading.Tasks;
+using MassTransit.Testing;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+using SearchApi.Core.Adapters.Contracts;
+using SearchApi.Core.Contracts;
+using SearchApi.Web.Search;
+
+namespace SearchApi.Web.Test.Search
+{
+    public class MatchFoundConsumerTest
+    {
+        private InMemoryTestHarness _harness;
+        private ConsumerTestHarness<MatchFoundConsumer> _sut;
+
+        private readonly Mock<ILogger<MatchFoundConsumer>> _loggerMock = new Mock<ILogger<MatchFoundConsumer>>();
+
+        [OneTimeSetUp]
+        public async Task A_consumer_is_being_tested()
+        {
+            _harness = new InMemoryTestHarness();
+            _sut = _harness.Consumer(() => new MatchFoundConsumer(_loggerMock.Object));
+
+            await _harness.Start();
+
+            await _harness.BusControl.Publish<MatchFound>(new
+            {
+                FirstName = "firstName",
+                LastName = "lastName",
+                DateOfBirth = new DateTime(2001, 1, 1)
+            });
+
+        }
+
+
+        [OneTimeTearDown]
+        public async Task Teardown()
+        {
+            await _harness.Stop();
+        }
+
+        [Test]
+        public void Should_send_the_initial_message_to_the_consumer()
+        {
+            Assert.IsTrue(_harness.Published.Select<MatchFound>().Any());
+        }
+
+        [Test]
+        public void Should_receive_the_message_type_a()
+        {
+            Assert.IsTrue(_harness.Consumed.Select<MatchFound>().Any());
+        }
+
+
+
+    }
+}

--- a/app/SearchApi/SearchApi.Web/Search/MatchFoundConsumer.cs
+++ b/app/SearchApi/SearchApi.Web/Search/MatchFoundConsumer.cs
@@ -1,0 +1,24 @@
+﻿using System.Threading.Tasks;
+using MassTransit;
+using Microsoft.Extensions.Logging;
+using SearchApi.Core.Adapters.Contracts;
+
+namespace SearchApi.Web.Search
+{
+    public class MatchFoundConsumer : IConsumer<MatchFound>
+    {
+
+        private readonly ILogger<MatchFoundConsumer> _logger;
+
+        public MatchFoundConsumer(ILogger<MatchFoundConsumer> logger)
+        {
+            this._logger = logger;
+        }
+
+        public async Task Consume(ConsumeContext<MatchFound> context)
+        {
+            this._logger.LogInformation($"received new {nameof(MatchFound)} event");
+            await Task.FromResult(0);
+        }
+    }
+}

--- a/app/SearchApi/SearchApi.Web/Startup.cs
+++ b/app/SearchApi/SearchApi.Web/Startup.cs
@@ -16,11 +16,13 @@ using Microsoft.Extensions.Logging;
 using NSwag;
 using OpenTracing;
 using OpenTracing.Util;
+using SearchApi.Core.Adapters.Contracts;
 using SearchApi.Core.Configuration;
 using SearchApi.Core.Contracts;
 using SearchApi.Core.MassTransit;
 using SearchApi.Core.OpenTracing;
 using SearchApi.Web.Controllers;
+using SearchApi.Web.Search;
 
 namespace SearchApi.Web
 {
@@ -151,6 +153,13 @@ namespace SearchApi.Web
 
                     // Add Diagnostic context for tracing
                     cfg.PropagateOpenTracingContext();
+
+                    // Configure MatchFound Consumer
+                    cfg.ReceiveEndpoint(host, $"{nameof(MatchFound)}_queue", e =>
+                        {
+                            e.Consumer(() =>
+                                new MatchFoundConsumer(provider.GetRequiredService<ILogger<MatchFoundConsumer>>()));
+                        });
 
                 }));
             });


### PR DESCRIPTION
This PR includes the following proposed changes:

* Search Api `MatchFoundConsumer` to consume result from adapters