### PR TITLE
Configuring Dynamics Adapter callback

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,8 @@ services:
       JAEGER_SERVICE_NAME: search-api
       JAEGER_SAMPLER_TYPE: const
       JAEGER_ENDPOINT: http://jaeger-collector:14268/api/traces
+      SearchApi__WebHooks__0__Name: Dynamics-Adapter
+      SearchApi__WebHooks__0__Uri: http://dynamics-adapter/MatchFound
     ports:
       - "5050:80"
     restart: always


### PR DESCRIPTION
# Description

This PR includes the following proposed changes:

* Set up webHooks for local `docker-compose` configuration

The response is now sent back to the dynamics adapter via webhooks:
![image](https://user-images.githubusercontent.com/51387119/68781129-25a1c180-05ec-11ea-9796-b2848cb68e63.png)

## Type of change

- [x] docker-compose configuration

# How Has This Been Tested?

Locally using docker

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
