### PR TITLE
Publish a PersonSearchFailed Message when Adapter Execution is failing

### DIFF
--- a/app/SearchApi/SearchApi.Core.Test/Adapters/Middleware/PersonSearchObserverTest.cs
+++ b/app/SearchApi/SearchApi.Core.Test/Adapters/Middleware/PersonSearchObserverTest.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using MassTransit;
+using MassTransit.Testing;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using NUnit.Framework;
+using OpenTracing.Mock;
+using SearchApi.Core.Adapters.Configuration;
+using SearchApi.Core.Adapters.Contracts;
+using SearchApi.Core.Adapters.Middleware;
+using SearchApi.Core.Contracts;
+
+namespace SearchAdapter.ICBC.Test.Adapters.Middleware
+{
+
+    public class PersonSearchObserverTest
+    {
+        private InMemoryTestHarness _harness;
+        private ConsumerTestHarness<FakeFailureConsumer> _fakeConsumerTestHarness;
+        private Mock<ILogger<PersonSearchObserver>> _personSearchObserver;
+        private Mock<IOptions<ProviderProfileOptions>> _providerProfileOptiosnMock;
+
+        [OneTimeSetUp]
+        public async Task A_consumer_is_being_tested()
+        {
+            _harness = new InMemoryTestHarness();
+            _fakeConsumerTestHarness = _harness.Consumer(() => new FakeFailureConsumer());
+
+            _personSearchObserver = new Mock<ILogger<PersonSearchObserver>>();
+            _providerProfileOptiosnMock = new Mock<IOptions<ProviderProfileOptions>>();
+
+            _providerProfileOptiosnMock.Setup(x => x.Value).Returns(new ProviderProfileOptions()
+            {
+                Name = "Adapter Tester"
+            });
+
+            await _harness.Start();
+
+            _harness.Bus.ConnectConsumeMessageObserver(new PersonSearchObserver(_providerProfileOptiosnMock.Object,
+                _personSearchObserver.Object));
+
+            await _harness.InputQueueSendEndpoint.Send<ExecuteSearch>(new
+            {
+                Id = Guid.NewGuid(),
+                FirstName = "firstName",
+                LastName = "lastName",
+                DateOfBirth = new DateTime(2001, 1, 1)
+            });
+        }
+
+        [Test]
+        public void With_failure_should_send_personSearchFailureEvent()
+        {
+            Assert.IsTrue(_harness.Published.Select<PersonSearchFailed>()
+                .Any(x => x.Context.Message.Cause.Message == "Test Exception"));
+        }
+
+
+        public class FakeFailureConsumer : IConsumer<ExecuteSearch>
+        {
+            public Task Consume(ConsumeContext<ExecuteSearch> context)
+            {
+                throw new Exception("Test Exception");
+            }
+        }
+
+    }
+}

--- a/app/SearchApi/SearchApi.Core.Test/SearchApi.Core.Test.csproj
+++ b/app/SearchApi/SearchApi.Core.Test/SearchApi.Core.Test.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0" />
+    <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="nunit" Version="3.12.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />

--- a/app/SearchApi/SearchApi.Core/Adapters/Contracts/PersonSearchEvent.cs
+++ b/app/SearchApi/SearchApi.Core/Adapters/Contracts/PersonSearchEvent.cs
@@ -1,0 +1,7 @@
+﻿namespace SearchApi.Core.Adapters.Contracts
+{
+    public class PersonSearchEvent
+    {
+        
+    }
+}

--- a/app/SearchApi/SearchApi.Core/Adapters/Contracts/PersonSearchEvent.cs
+++ b/app/SearchApi/SearchApi.Core/Adapters/Contracts/PersonSearchEvent.cs
@@ -1,7 +1,11 @@
-﻿namespace SearchApi.Core.Adapters.Contracts
+﻿using System;
+
+namespace SearchApi.Core.Adapters.Contracts
 {
-    public class PersonSearchEvent
+    public interface PersonSearchEvent
     {
-        
+        Guid SearchRequestId { get; }
+
+        ProviderProfile ProviderProfile { get; }
     }
 }

--- a/app/SearchApi/SearchApi.Core/Adapters/Contracts/PersonSearchFailed.cs
+++ b/app/SearchApi/SearchApi.Core/Adapters/Contracts/PersonSearchFailed.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace SearchApi.Core.Adapters.Contracts
+{
+    public interface PersonSearchFailed : PersonSearchEvent
+    {
+        Exception Cause { get; }
+    }
+}

--- a/app/SearchApi/SearchApi.Core/Adapters/Contracts/PersonSearchRejected.cs
+++ b/app/SearchApi/SearchApi.Core/Adapters/Contracts/PersonSearchRejected.cs
@@ -4,10 +4,8 @@ using SearchApi.Core.Adapters.Models;
 
 namespace SearchApi.Core.Adapters.Contracts
 {
-    public interface PersonSearchRejected
+    public interface PersonSearchRejected : PersonSearchEvent
     {
-        Guid SearchRequestId { get; }
-        ProviderProfile ProviderProfile { get; }
         IEnumerable<ValidationResult> Reasons { get; }
     }
 }

--- a/app/SearchApi/SearchApi.Core/Adapters/Middleware/PersonSearchObserver.cs
+++ b/app/SearchApi/SearchApi.Core/Adapters/Middleware/PersonSearchObserver.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Threading.Tasks;
+using MassTransit;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using SearchApi.Core.Adapters.Configuration;
+using SearchApi.Core.Adapters.Contracts;
+using SearchApi.Core.Adapters.Models;
+using SearchApi.Core.Contracts;
+
+namespace SearchApi.Core.Adapters.Middleware
+{
+    public class PersonSearchObserver : IConsumeMessageObserver<ExecuteSearch>
+    {
+
+        private readonly ProviderProfile _providerProfile;
+        private readonly ILogger<PersonSearchObserver> _logger;
+
+        public PersonSearchObserver(IOptions<ProviderProfileOptions> providerProfile, ILogger<PersonSearchObserver> logger)
+        {
+            _logger = logger;
+            _providerProfile = providerProfile.Value;
+        }
+
+        public async Task PreConsume(ConsumeContext<ExecuteSearch> context)
+        {
+            _logger.LogInformation($"Adapter {_providerProfile.Name} provider received new person search request.");
+            await Task.FromResult(0);
+            return;
+        }
+
+        public async Task PostConsume(ConsumeContext<ExecuteSearch> context)
+        {
+            _logger.LogInformation($"Adapter {_providerProfile.Name} provider successfully processed new person search request.");
+            await Task.FromResult(0);
+            return;
+        }
+
+        public async Task ConsumeFault(ConsumeContext<ExecuteSearch> context, Exception exception)
+        {
+            _logger.LogError(exception, "Adapter Failed to execute person search.");
+            await context.Publish<PersonSearchFailed>(new PersonSearchFailedEvent()
+            {
+                SearchRequestId = context.Message.Id,
+                ProviderProfile = _providerProfile,
+                Cause = exception
+            });
+        }
+    }
+}

--- a/app/SearchApi/SearchApi.Core/Adapters/Models/PersonSearchFailedEvent.cs
+++ b/app/SearchApi/SearchApi.Core/Adapters/Models/PersonSearchFailedEvent.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using SearchApi.Core.Adapters.Contracts;
+
+namespace SearchApi.Core.Adapters.Models
+{
+    public class PersonSearchFailedEvent : PersonSearchFailed
+    {
+        public Guid SearchRequestId { get; set; }
+        public ProviderProfile ProviderProfile { get; set; }
+        public Exception Cause { get; set; }
+    }
+}


### PR DESCRIPTION
# Description

This PR includes the following proposed changed:

- A new `PersonSearch` Observer that report on adapter failures to the `SearchApi`

The Blue line represents the change:

![failure-report](https://user-images.githubusercontent.com/51387119/69581024-98b31c80-0f8a-11ea-8abd-b480dd3bcad9.png)


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## For bcgov contributors:

this PR fixes jira ticket: **FAMS3-779**
