### PR TITLE
Publish a personSearchAccepted message when validation succeed

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,28 @@ With this configuration the searchApi will post MatchFound to `http://localhost:
 }
 ```
 
+## Search Adapters
+
+The Search Adpaters a worker that execute a search for a specific data providers.
+
+SearchAdapter produce the following events:
+
+### MatchFound
+
+When the Adapter found a match for a particular person
+
+### Person Search Accepted
+
+When a person Search is accepted, meaning it has sufficient information to conduct a search.
+
+### Person Search Rejected
+
+When a person Search does not meet the minimal requirement for the adapter to conduct a search.
+
+### Person Search Failed
+
+When the adpater throws an unknown exception.
+
 #### OpenApi
 
 The Search Api uses [NSwag](https://github.com/RicoSuter/NSwag) to autogenerate api specification from the code.

--- a/app/SearchApi/SearchAdapter.ICBC.Test/SearchRequest/SearchRequestConsumerTest.cs
+++ b/app/SearchApi/SearchAdapter.ICBC.Test/SearchRequest/SearchRequestConsumerTest.cs
@@ -98,12 +98,16 @@ namespace SearchAdapter.ICBC.Test.SearchRequest
             Assert.IsTrue(_harness.Published.Select<PersonSearchRejected>().Any(x => x.Context.Message.SearchRequestId == inValidGuid));
         }
 
-
         [Test]
         public void Should_send_a_match_found_event()
         {
             Assert.IsTrue(_harness.Published.Select<SearchApi.Core.Adapters.Contracts.MatchFound>().Any(x => x.Context.Message.SearchRequestId == validGuid));
         }
 
+        [Test]
+        public void Should_send_a_search_accepted_event()
+        {
+            Assert.IsTrue(_harness.Published.Select<PersonSearchAccepted>().Any(x => x.Context.Message.SearchRequestId == validGuid));
+        }
     }
 }

--- a/app/SearchApi/SearchApi.Core/Adapters/Contracts/PersonSearchAccepted.cs
+++ b/app/SearchApi/SearchApi.Core/Adapters/Contracts/PersonSearchAccepted.cs
@@ -1,0 +1,7 @@
+﻿namespace SearchApi.Core.Adapters.Contracts
+{
+    public interface PersonSearchAccepted : PersonSearchEvent
+    {
+        
+    }
+}

--- a/app/SearchApi/SearchApi.Core/Adapters/Models/DefaultPersonSearchAccepted.cs
+++ b/app/SearchApi/SearchApi.Core/Adapters/Models/DefaultPersonSearchAccepted.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using SearchApi.Core.Adapters.Contracts;
+
+namespace SearchApi.Core.Adapters.Models
+{
+    public class DefaultPersonSearchAccepted : PersonSearchAccepted
+    {
+        public DefaultPersonSearchAccepted(Guid searchRequestId, ProviderProfile providerProfile)
+        {
+            SearchRequestId = searchRequestId;
+            ProviderProfile = providerProfile;
+        }
+
+        public Guid SearchRequestId { get; }
+        public ProviderProfile ProviderProfile { get; }
+    }
+}


### PR DESCRIPTION
# Description

This PR includes the following proposed changes:

- A new `PersonSearchAccepted` event sent when the adapter search pass the validation

Architecture Change are represented  with the blue line:

![personSearchAccepted](https://user-images.githubusercontent.com/51387119/69582339-4293a880-0f8d-11ea-96ef-596309e3d4cf.png)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## For bcgov contributors:

this PR fixes jira ticket: **FAMS3-778**
