### PR TITLE
Add a new function in SearchApiService to create a new status report

### DIFF
--- a/app/DynamicsAdapter/DynamicsAdapter.Web.Test/PersonSearch/PersonSearchControllerTest.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web.Test/PersonSearch/PersonSearchControllerTest.cs
@@ -1,6 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
 using DynamicsAdapter.Web.PersonSearch;
+using Fams3Adapter.Dynamics.Identifier;
+using Fams3Adapter.Dynamics.SearchApiEvent;
+using Fams3Adapter.Dynamics.SearchApiRequest;
 using Fams3Adapter.Dynamics.SearchRequest;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -11,25 +16,100 @@ namespace DynamicsAdapter.Web.Test.PersonSearch
 {
     public class PersonSearchControllerTest
     {
+
+        private Guid _testGuid;
+        private Guid _exceptionGuid;
+
         private PersonSearchController _sut;
-        private readonly Mock<ILogger<PersonSearchController>> _loggerMock = new Mock<ILogger<PersonSearchController>>();
-        private readonly Mock<ISearchRequestService> _searchRequestServiceMock = new Mock<ISearchRequestService>();
+        private Mock<ILogger<PersonSearchController>> _loggerMock ;
+        private Mock<ISearchRequestService> _searchRequestServiceMock;
+        private Mock<ISearchApiRequestService> _searchApiRequestServiceMock;
 
         [SetUp]
         public void Init()
         {
-            _sut = new PersonSearchController(_loggerMock.Object, _searchRequestServiceMock.Object);
+
+            _testGuid = Guid.NewGuid();
+            _exceptionGuid = Guid.NewGuid();
+            _loggerMock = new Mock<ILogger<PersonSearchController>>();
+            _searchApiRequestServiceMock = new Mock<ISearchApiRequestService>();
+            _searchRequestServiceMock = new Mock<ISearchRequestService>();
+
+
+            _searchRequestServiceMock.Setup(x => x.UploadIdentifier(It.Is<SSG_Identifier>(x => x.SSG_SearchRequest.SearchRequestId == _testGuid), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult<SSG_Identifier>(new SSG_Identifier()
+                {
+                    Identification = "test identification"
+                }));
+
+            _searchRequestServiceMock.Setup(x => x.UploadIdentifier(It.Is<SSG_Identifier>(x => x.SSG_SearchRequest.SearchRequestId == _exceptionGuid), It.IsAny<CancellationToken>()))
+                .Throws(new Exception("random exception"));
+
+            _searchApiRequestServiceMock.Setup(x => x.AddEventAsync(It.Is<Guid>(x => x == _testGuid),
+                    It.IsAny<SSG_SearchApiEvent>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult<SSG_SearchApiEvent>(new SSG_SearchApiEvent()
+                {
+                    Id = _testGuid,
+                    Name = "Random Event"
+                }));
+
+            _searchApiRequestServiceMock.Setup(x => x.AddEventAsync(It.Is<Guid>(x => x == _exceptionGuid),
+                    It.IsAny<SSG_SearchApiEvent>(), It.IsAny<CancellationToken>()))
+                .Throws(new Exception("random exception"));
+
+            _sut = new PersonSearchController(_searchRequestServiceMock.Object, _searchApiRequestServiceMock.Object, _loggerMock.Object);
         }
 
         [Test]
-        public void with_valid_match_found_data_should_return_ok()
+        public async Task With_valid_match_found_data_should_return_ok()
         {
-            Guid id = new Guid();
-            IActionResult result = (OkResult)this._sut.MatchFound(id, new Web.PersonSearch.MatchFound()
+            var result = await _sut.MatchFound(_testGuid, new MatchFound()
             {
                 PersonIds = new List<PersonId>()
-            }).Result;
-            Assert.IsNotNull(result);
+                {
+                    new PersonId()
+                    {
+                        Issuer = "test",
+                        Number = "test",
+                        Kind = PersonIDKind.DriverLicense
+                    }
+                }
+            });
+            Assert.IsInstanceOf(typeof(OkResult), result);
+
+        }
+
+        [Test]
+        public async Task With_exception_match_found_data_should_return_badrequest()
+        {
+            var result = await _sut.MatchFound(_exceptionGuid, new MatchFound()
+            {
+                PersonIds = new List<PersonId>()
+                {
+                    new PersonId()
+                    {
+                        Issuer = "test",
+                        Number = "test",
+                        Kind = PersonIDKind.DriverLicense
+                    }
+                }
+            });
+            Assert.IsInstanceOf(typeof(BadRequestResult), result);
+        }
+
+        [Test]
+        public async Task With_valid_event_it_should_return_ok()
+        {
+            var result = await _sut.Event(_testGuid, null);
+            Assert.IsInstanceOf(typeof(OkResult), result);
+        }
+
+
+        [Test]
+        public async Task With_exception_event_it_should_return_badrequest()
+        {
+            var result = await _sut.Event(_exceptionGuid, null);
+            Assert.IsInstanceOf(typeof(BadRequestResult), result);
         }
 
     }

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/SearchRequest/SearchRequestJob.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/SearchRequest/SearchRequestJob.cs
@@ -41,7 +41,7 @@ namespace DynamicsAdapter.Web.SearchRequest
 
             var cts = new CancellationTokenSource();
 
-            try
+            try 
             {
                 List<SSG_SearchApiRequest> requestList = await GetAllReadyForSearchAsync(cts.Token);
 

--- a/app/DynamicsAdapter/Fams3Adapter.Dynamics.Test/SearchApiRequest/SearchApiRequestServiceAddEventTest.cs
+++ b/app/DynamicsAdapter/Fams3Adapter.Dynamics.Test/SearchApiRequest/SearchApiRequestServiceAddEventTest.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Fams3Adapter.Dynamics.SearchApiEvent;
+using Fams3Adapter.Dynamics.SearchApiRequest;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollection;
+using Moq;
+using NUnit.Framework;
+using Simple.OData.Client;
+
+namespace Fams3Adapter.Dynamics.Test.SearchApiRequest
+{
+    public class SearchApiRequestServiceAddEventTest
+    {
+        private Mock<IODataClient> odataClientMock = new Mock<IODataClient>();
+
+        private Guid _testId;
+
+        private SearchApiRequestService _sut;
+
+        private const string eventName = "TEST_EVENT";
+
+        [SetUp]
+        public void SetUp()
+        {
+
+            _testId = Guid.NewGuid();
+
+            int readyForSearchVAlue = SearchApiRequestStatusReason.ReadyForSearch.Value;
+            int inProgressValue = SearchApiRequestStatusReason.InProgress.Value;
+
+            odataClientMock.Setup(x => x
+                    .For<SSG_SearchApiEvent>(null)
+                    .Set(It.Is<SSG_SearchApiEvent>(x => x.Name == eventName))
+                    .InsertEntryAsync(It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult<SSG_SearchApiEvent>(new SSG_SearchApiEvent()
+                {
+                    Name = eventName,
+                    Id = _testId
+                }));
+
+            _sut = new SearchApiRequestService(odataClientMock.Object);
+
+        }
+
+
+        [Test]
+        public async Task with_success_should_return_event()
+        {
+
+            var searchApiEvent = new SSG_SearchApiEvent()
+            {
+                Name = eventName
+            };
+
+            var result = await _sut.AddEventAsync(_testId, searchApiEvent, CancellationToken.None);
+            Assert.AreEqual(_testId, result.Id);
+            Assert.AreEqual(eventName, result.Name);
+        }
+
+        [Test]
+        public void With_empty_guid_should_throw_ArgumentNullException()
+        {
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await _sut.AddEventAsync(Guid.Empty, null, CancellationToken.None));
+        }
+
+
+    }
+}

--- a/app/DynamicsAdapter/Fams3Adapter.Dynamics/SearchApiEvent/SSG_SearchApiEvent.cs
+++ b/app/DynamicsAdapter/Fams3Adapter.Dynamics/SearchApiEvent/SSG_SearchApiEvent.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using Fams3Adapter.Dynamics.SearchApiRequest;
+using Fams3Adapter.Dynamics.SearchRequest;
+using Newtonsoft.Json;
+
+namespace Fams3Adapter.Dynamics.SearchApiEvent
+{
+    /// <summary>
+    /// Represents FAMS3 Dynamics SearchApiEvent
+    /// </summary>
+    public class SSG_SearchApiEvent
+    {
+        [JsonProperty("ssg_searchapieventid")]
+        public Guid Id { get; set; }
+        [JsonProperty("ssg_name")] 
+        public string Name { get; set; }
+        [JsonProperty("ssg_eventtype")]
+        public string Type { get; set; }
+        [JsonProperty("ssg_eventmessage")]
+        public string Message { get; set; }
+        [JsonProperty("ssg_providername")]
+        public string ProviderName { get; set; }
+        [JsonProperty("ssg_timestamp")]
+        public DateTime TimeStamp { get; set; }
+        [JsonProperty("ssg_SearchAPIRequest")]
+        public virtual SSG_SearchApiRequest SearchApiRequest { get; set; }
+    }
+}

--- a/app/DynamicsAdapter/Fams3Adapter.Dynamics/SearchApiRequest/SearchApiRequestService.cs
+++ b/app/DynamicsAdapter/Fams3Adapter.Dynamics/SearchApiRequest/SearchApiRequestService.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic;
 using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
+using Fams3Adapter.Dynamics.SearchApiEvent;
+using Fams3Adapter.Dynamics.SearchRequest;
 using Simple.OData.Client;
 
 using Entry = System.Collections.Generic.Dictionary<string, object>;
@@ -16,6 +18,9 @@ namespace Fams3Adapter.Dynamics.SearchApiRequest
         Task<IEnumerable<SSG_SearchApiRequest>> GetAllReadyForSearchAsync(CancellationToken cancellationToken);
 
         Task<SSG_SearchApiRequest> MarkInProgress(Guid searchApiRequestId, CancellationToken cancellationToken);
+
+        Task<SSG_SearchApiEvent> AddEventAsync(Guid searchApiRequestId, SSG_SearchApiEvent searchApiEvent,
+            CancellationToken cancellationToken);
     }
 
     /// <summary>
@@ -59,7 +64,7 @@ namespace Fams3Adapter.Dynamics.SearchApiRequest
             return results;       
         }
 
-        /// <summary>(
+        /// <summary>
         /// Marks a search request in Progress
         /// </summary>
         /// <param name="searchApiRequestId"></param>
@@ -75,6 +80,18 @@ namespace Fams3Adapter.Dynamics.SearchApiRequest
                 .Set(new Entry { { Keys.DYNAMICS_STATUS_CODE_FIELD, SearchApiRequestStatusReason.InProgress.Value } })
                 .UpdateEntryAsync(cancellationToken);
         }
+
+
+        public async Task<SSG_SearchApiEvent> AddEventAsync(Guid searchApiRequestId, SSG_SearchApiEvent searchApiEvent,
+            CancellationToken cancellationToken)
+        {
+            if (searchApiRequestId == default || searchApiRequestId == Guid.Empty) throw new ArgumentNullException(nameof(searchApiRequestId));
+
+            searchApiEvent.SearchApiRequest = new SSG_SearchApiRequest() { SearchApiRequestId = searchApiRequestId};
+
+            return await this._oDataClient.For<SSG_SearchApiEvent>().Set(searchApiEvent).InsertEntryAsync(cancellationToken);
+        }
+
 
     }
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed changes:

- A new function for the `SearchApiRequestService` to add a new event.
- A new endpoint in `PersonSearchController` to receive notifications

Architecture change:

![add-event](https://user-images.githubusercontent.com/51387119/69663483-2ea68000-103b-11ea-8344-3927c0a057ef.png)



## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Locally, with docker connected to FAMS3 dev instance

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## For bcgov contributors:

this PR fixes jira ticket: **FAMS3-771**
