### PR TITLE
Change workflow to use the SearchApiRequest Id instead of the SearchRequestId

### DIFF
--- a/app/DynamicsAdapter/DynamicsAdapter.Web.Test/PersonSearch/PersonSearchControllerTest.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web.Test/PersonSearch/PersonSearchControllerTest.cs
@@ -35,14 +35,24 @@ namespace DynamicsAdapter.Web.Test.PersonSearch
             _searchApiRequestServiceMock = new Mock<ISearchApiRequestService>();
             _searchRequestServiceMock = new Mock<ISearchRequestService>();
 
+            var validRequestId = Guid.NewGuid();
+            var invalidRequestId = Guid.NewGuid();
 
-            _searchRequestServiceMock.Setup(x => x.UploadIdentifier(It.Is<SSG_Identifier>(x => x.SSG_SearchRequest.SearchRequestId == _testGuid), It.IsAny<CancellationToken>()))
+
+            _searchApiRequestServiceMock.Setup(x => x.GetLinkedSearchRequestIdAsync(It.Is<Guid>(x => x == _testGuid), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult<Guid>(_testGuid));
+
+            _searchApiRequestServiceMock.Setup(x => x.GetLinkedSearchRequestIdAsync(It.Is<Guid>(x => x == _exceptionGuid), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult<Guid>(invalidRequestId));
+
+
+            _searchRequestServiceMock.Setup(x => x.UploadIdentifier(It.Is<SSG_Identifier>(x => x.SSG_SearchRequest.SearchRequestId == validRequestId), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult<SSG_Identifier>(new SSG_Identifier()
                 {
                     Identification = "test identification"
                 }));
 
-            _searchRequestServiceMock.Setup(x => x.UploadIdentifier(It.Is<SSG_Identifier>(x => x.SSG_SearchRequest.SearchRequestId == _exceptionGuid), It.IsAny<CancellationToken>()))
+            _searchRequestServiceMock.Setup(x => x.UploadIdentifier(It.Is<SSG_Identifier>(x => x.SSG_SearchRequest.SearchRequestId == invalidRequestId), It.IsAny<CancellationToken>()))
                 .Throws(new Exception("random exception"));
 
             _searchApiRequestServiceMock.Setup(x => x.AddEventAsync(It.Is<Guid>(x => x == _testGuid),
@@ -58,6 +68,7 @@ namespace DynamicsAdapter.Web.Test.PersonSearch
                 .Throws(new Exception("random exception"));
 
             _sut = new PersonSearchController(_searchRequestServiceMock.Object, _searchApiRequestServiceMock.Object, _loggerMock.Object);
+
         }
 
         [Test]

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/PersonSearch/PersonSearchController.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/PersonSearch/PersonSearchController.cs
@@ -72,34 +72,34 @@ namespace DynamicsAdapter.Web.PersonSearch
             _logger.LogInformation("Received MatchFound response with SearchRequestId is " + id);
             var cts = new CancellationTokenSource();
 
-            foreach (var matchFoundPersonId in matchFound.PersonIds)
+            try
             {
+                var searchApiRequestId = await _searchApiRequestService.GetLinkedSearchRequestIdAsync(id, cts.Token);
 
-                //TODO: replaced with data from payload
-                var toBeReplaced = new SSG_Identifier()
+                foreach (var matchFoundPersonId in matchFound.PersonIds)
                 {
-                    Identification = matchFoundPersonId.Number,
-                    IdentificationEffectiveDate = new DateTime(2014, 1, 1),
-                    IdentifierType = IdentificationType.DriverLicense.Value,
-                    IssuedBy = "ICBC",
-                    SSG_SearchRequest = new SSG_SearchRequest()
+                    //TODO: replaced with data from payload
+                    var toBeReplaced = new SSG_Identifier()
                     {
-                        SearchRequestId = id
-                    },
-                    StateCode = 0,
-                    StatusCode = 1
-                };
-
-                try
-                {
+                        Identification = matchFoundPersonId.Number,
+                        IdentificationEffectiveDate = new DateTime(2014, 1, 1),
+                        IdentifierType = IdentificationType.DriverLicense.Value,
+                        IssuedBy = "ICBC",
+                        SSG_SearchRequest = new SSG_SearchRequest()
+                        {
+                            SearchRequestId = searchApiRequestId
+                        },
+                        StateCode = 0,
+                        StatusCode = 1
+                    };
                     var result = await _searchRequestService.UploadIdentifier(toBeReplaced, cts.Token);
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError(ex.Message);
-                    return BadRequest();
-                }
 
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex.Message);
+                return BadRequest();
             }
 
             return Ok();

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/SearchRequest/SearchRequestJob.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/SearchRequest/SearchRequestJob.cs
@@ -55,7 +55,7 @@ namespace DynamicsAdapter.Web.SearchRequest
                         FirstName = ssgSearchRequest.PersonGivenName,
                         LastName = ssgSearchRequest.PersonSurname,
                         DateOfBirth = ssgSearchRequest.PersonBirthDate,
-                    }, $"{ssgSearchRequest.SearchRequestId}", cts.Token);
+                    }, $"{ssgSearchRequest.SearchApiRequestId}", cts.Token);
                     _logger.LogInformation($"Successfully posted person search id:{result.Id}");
 
                     await MarkInProgress(ssgSearchRequest, cts.Token);

--- a/app/DynamicsAdapter/Fams3Adapter.Dynamics.Test/SearchApiRequest/SearchApiRequestServiceGetLinkedSearchRequestIdAsyncTest.cs
+++ b/app/DynamicsAdapter/Fams3Adapter.Dynamics.Test/SearchApiRequest/SearchApiRequestServiceGetLinkedSearchRequestIdAsyncTest.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading;
+using System.Threading.Tasks;
+using Fams3Adapter.Dynamics.SearchApiEvent;
+using Fams3Adapter.Dynamics.SearchApiRequest;
+using Microsoft.VisualStudio.TestPlatform.ObjectModel.DataCollection;
+using Moq;
+using NUnit.Framework;
+using Simple.OData.Client;
+
+namespace Fams3Adapter.Dynamics.Test.SearchApiRequest
+{
+    public class SearchApiRequestServiceGetLinkedSearchRequestIdAsyncTest
+    {
+        private Mock<IODataClient> odataClientMock = new Mock<IODataClient>();
+
+        private Guid _testId;
+        private Guid _searchRequestId;
+
+        private SearchApiRequestService _sut;
+
+        private const string eventName = "TEST_EVENT";
+
+        [SetUp]
+        public void SetUp()
+        {
+
+            _testId = Guid.NewGuid();
+            _searchRequestId = Guid.NewGuid();
+
+            odataClientMock.Setup(x => x.For<SSG_SearchApiRequest>(null)
+                .Key(It.Is<Guid>(x => x == _testId))
+                .Select(x => x.SearchRequestId)
+                .FindEntryAsync(It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult<SSG_SearchApiRequest>(new SSG_SearchApiRequest()
+                {
+                    SearchRequestId = _searchRequestId
+                }));
+
+            _sut = new SearchApiRequestService(odataClientMock.Object);
+
+        }
+
+
+        [Test]
+        public async Task with_success_should_return_event()
+        {
+            var result = await _sut.GetLinkedSearchRequestIdAsync(_testId, CancellationToken.None);
+            Assert.AreEqual(_searchRequestId, result);
+        }
+
+        [Test]
+        public void With_empty_guid_should_throw_ArgumentNullException()
+        {
+            Assert.ThrowsAsync<ArgumentNullException>(async () => await _sut.GetLinkedSearchRequestIdAsync(Guid.Empty, CancellationToken.None));
+        }
+
+
+    }
+}

--- a/app/DynamicsAdapter/Fams3Adapter.Dynamics/SearchApiRequest/SearchApiRequestService.cs
+++ b/app/DynamicsAdapter/Fams3Adapter.Dynamics/SearchApiRequest/SearchApiRequestService.cs
@@ -93,5 +93,19 @@ namespace Fams3Adapter.Dynamics.SearchApiRequest
         }
 
 
+        public async Task<Guid> GetLinkedSearchRequestIdAsync(Guid searchApiRequestId,
+            CancellationToken cancellationToken)
+        {
+            if (searchApiRequestId == default || searchApiRequestId == Guid.Empty) throw new ArgumentNullException(nameof(searchApiRequestId));
+
+            var result = await _oDataClient
+                .For<SSG_SearchApiRequest>()
+                .Key(searchApiRequestId)
+                .Select(x => x.SearchRequestId)
+                .FindEntryAsync(cancellationToken);
+
+            return result.SearchRequestId;
+        }
+
     }
 }

--- a/app/DynamicsAdapter/Fams3Adapter.Dynamics/SearchApiRequest/SearchApiRequestService.cs
+++ b/app/DynamicsAdapter/Fams3Adapter.Dynamics/SearchApiRequest/SearchApiRequestService.cs
@@ -17,10 +17,15 @@ namespace Fams3Adapter.Dynamics.SearchApiRequest
     {
         Task<IEnumerable<SSG_SearchApiRequest>> GetAllReadyForSearchAsync(CancellationToken cancellationToken);
 
+        Task<Guid> GetLinkedSearchRequestIdAsync(Guid searchApiRequestId,
+            CancellationToken cancellationToken);
+
         Task<SSG_SearchApiRequest> MarkInProgress(Guid searchApiRequestId, CancellationToken cancellationToken);
 
         Task<SSG_SearchApiEvent> AddEventAsync(Guid searchApiRequestId, SSG_SearchApiEvent searchApiEvent,
             CancellationToken cancellationToken);
+
+        
     }
 
     /// <summary>
@@ -65,6 +70,26 @@ namespace Fams3Adapter.Dynamics.SearchApiRequest
         }
 
         /// <summary>
+        /// Get the corresponding searchRequestId give a searchApiRequestId
+        /// </summary>
+        /// <param name="searchApiRequestId"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        public async Task<Guid> GetLinkedSearchRequestIdAsync(Guid searchApiRequestId,
+            CancellationToken cancellationToken)
+        {
+            if (searchApiRequestId == default || searchApiRequestId == Guid.Empty) throw new ArgumentNullException(nameof(searchApiRequestId));
+
+            var result = await _oDataClient
+                .For<SSG_SearchApiRequest>()
+                .Key(searchApiRequestId)
+                .Select(x => x.SearchRequestId)
+                .FindEntryAsync(cancellationToken);
+
+            return result.SearchRequestId;
+        }
+
+        /// <summary>
         /// Marks a search request in Progress
         /// </summary>
         /// <param name="searchApiRequestId"></param>
@@ -90,21 +115,6 @@ namespace Fams3Adapter.Dynamics.SearchApiRequest
             searchApiEvent.SearchApiRequest = new SSG_SearchApiRequest() { SearchApiRequestId = searchApiRequestId};
 
             return await this._oDataClient.For<SSG_SearchApiEvent>().Set(searchApiEvent).InsertEntryAsync(cancellationToken);
-        }
-
-
-        public async Task<Guid> GetLinkedSearchRequestIdAsync(Guid searchApiRequestId,
-            CancellationToken cancellationToken)
-        {
-            if (searchApiRequestId == default || searchApiRequestId == Guid.Empty) throw new ArgumentNullException(nameof(searchApiRequestId));
-
-            var result = await _oDataClient
-                .For<SSG_SearchApiRequest>()
-                .Key(searchApiRequestId)
-                .Select(x => x.SearchRequestId)
-                .FindEntryAsync(cancellationToken);
-
-            return result.SearchRequestId;
         }
 
     }


### PR DESCRIPTION
# Description

This PR includes the following proposed change:

- use the `searchApiRequestId` as the main driver of the search

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Local + Docker with Dynamics

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## For bcgov contributors:

this PR fixes jira ticket: **FAMS3-790**
