### PR TITLE
Publish new PersonSearchOrdered events to all adapters

### DIFF
--- a/app/SearchApi/SearchAdapter.ICBC.Test/SearchRequest/SearchRequestConsumerTest.cs
+++ b/app/SearchApi/SearchAdapter.ICBC.Test/SearchRequest/SearchRequestConsumerTest.cs
@@ -33,7 +33,7 @@ namespace SearchAdapter.ICBC.Test.SearchRequest
         private Guid inValidGuid = Guid.NewGuid();
 
 
-            [OneTimeSetUp]
+        [OneTimeSetUp]
         public async Task A_consumer_is_being_tested()
         {
 
@@ -41,10 +41,10 @@ namespace SearchAdapter.ICBC.Test.SearchRequest
             _providerProfileMock = new Mock<IOptions<ProviderProfileOptions>>();
             _personSearchValidatorMock = new Mock<IValidator<ExecuteSearch>>();
 
-            _personSearchValidatorMock.Setup(x => x.Validate(It.Is<ExecuteSearch>(x => x.Id == validGuid)))
+            _personSearchValidatorMock.Setup(x => x.Validate(It.Is<ExecuteSearch>(executeSearch => !string.IsNullOrEmpty(executeSearch.FirstName))))
                 .Returns(new ValidationResult(Enumerable.Empty<ValidationFailure>()));
 
-            _personSearchValidatorMock.Setup(x => x.Validate(It.Is<ExecuteSearch>(x => x.Id == inValidGuid)))
+            _personSearchValidatorMock.Setup(x => x.Validate(It.Is<ExecuteSearch>(executeSearch => string.IsNullOrEmpty(executeSearch.FirstName))))
                 .Returns(new ValidationResult(new List<ValidationFailure>()
                 {
                     new ValidationFailure("firstName", "firstName is required.")

--- a/app/SearchApi/SearchAdapter.ICBC/SearchRequest/SearchRequestConsumer.cs
+++ b/app/SearchApi/SearchAdapter.ICBC/SearchRequest/SearchRequestConsumer.cs
@@ -17,7 +17,7 @@ namespace SearchAdapter.ICBC.SearchRequest
     /// <summary>
     /// The SearchRequestConsumer consumes ICBC execute search commands, execute the search a publish a response back to the searchApi
     /// </summary>
-    public class SearchRequestConsumer : IConsumer<ExecuteSearch>
+    public class SearchRequestConsumer : IConsumer<PersonSearchOrdered>
     {
 
         private readonly ILogger<SearchRequestConsumer> _logger;
@@ -35,9 +35,9 @@ namespace SearchAdapter.ICBC.SearchRequest
             _logger = logger;
         }
 
-        public async Task Consume(ConsumeContext<ExecuteSearch> context)
+        public async Task Consume(ConsumeContext<PersonSearchOrdered> context)
         {
-            _logger.LogInformation($"Successfully handling new search request [{context.Message.Id}]");
+            _logger.LogInformation($"Successfully handling new search request [{context.Message.ExecuteSearch}]");
 
             _logger.LogWarning("Currently under development, ICBC Adapter is generating FAKE results.");
 
@@ -47,21 +47,21 @@ namespace SearchAdapter.ICBC.SearchRequest
             }
         }
 
-        private async Task<bool> ValidatePersonSearch(ConsumeContext<ExecuteSearch> context)
+        private async Task<bool> ValidatePersonSearch(ConsumeContext<PersonSearchOrdered> context)
         {
 
             _logger.LogDebug("Attempting to validate the personSearch");
-            var validation = _personSearchValidator.Validate(context.Message);
+            var validation = _personSearchValidator.Validate(context.Message.ExecuteSearch);
 
             if (validation.IsValid)
             {
-                await context.Publish<PersonSearchAccepted>(new DefaultPersonSearchAccepted(context.Message.Id, _profile));
+                await context.Publish<PersonSearchAccepted>(new DefaultPersonSearchAccepted(context.Message.SearchRequestId, _profile));
             }
             else
             {
                 _logger.LogInformation("PersonSearch does not have sufficient information for the adapter to proceed the search.");
 
-                var rejectionEvent = new PersonSearchRejectedEvent(context.Message.Id, _profile);
+                var rejectionEvent = new PersonSearchRejectedEvent(context.Message.SearchRequestId, _profile);
 
                 validation.Errors.ToList().ForEach(x => rejectionEvent.AddValidationResult(new ValidationResult()
                 {
@@ -77,18 +77,15 @@ namespace SearchAdapter.ICBC.SearchRequest
         }
 
 
-        public SearchApi.Core.Adapters.Contracts.MatchFound BuildFakeResult(ExecuteSearch executeSearch)
+        public SearchApi.Core.Adapters.Contracts.MatchFound BuildFakeResult(PersonSearchOrdered personSearchOrdered)
         {
-
-
             var fakeIdentifier = new IcbcPersonIdBuilder(PersonIDKind.DriverLicense).WithIssuer("British Columbia")
                 .WithNumber("1234568").Build();
 
-            var person = new IcbcPersonBuilder().WithFirstName(executeSearch.FirstName)
-                .WithFirstName(executeSearch.FirstName).WithDateOfBirth(executeSearch.DateOfBirth).Build();
+            var person = new IcbcPersonBuilder().WithFirstName(personSearchOrdered.ExecuteSearch.FirstName)
+                .WithFirstName(personSearchOrdered.ExecuteSearch.FirstName).WithDateOfBirth(personSearchOrdered.ExecuteSearch.DateOfBirth).Build();
 
-
-            return new IcbcMatchFoundBuilder(executeSearch.Id).WithPerson(person).AddPersonId(fakeIdentifier).Build();
+            return new IcbcMatchFoundBuilder(personSearchOrdered.SearchRequestId).WithPerson(person).AddPersonId(fakeIdentifier).Build();
 
         }
 

--- a/app/SearchApi/SearchApi.Core/Adapters/Contracts/AdapterEvent.cs
+++ b/app/SearchApi/SearchApi.Core/Adapters/Contracts/AdapterEvent.cs
@@ -1,0 +1,7 @@
+﻿namespace SearchApi.Core.Adapters.Contracts
+{
+    public interface AdapterEvent
+    {
+        ProviderProfile ProviderProfile { get; }
+    }
+}

--- a/app/SearchApi/SearchApi.Core/Adapters/Contracts/PersonSearchAccepted.cs
+++ b/app/SearchApi/SearchApi.Core/Adapters/Contracts/PersonSearchAccepted.cs
@@ -1,6 +1,6 @@
 ﻿namespace SearchApi.Core.Adapters.Contracts
 {
-    public interface PersonSearchAccepted : PersonSearchEvent
+    public interface PersonSearchAccepted : PersonSearchEvent, AdapterEvent
     {
         
     }

--- a/app/SearchApi/SearchApi.Core/Adapters/Contracts/PersonSearchEvent.cs
+++ b/app/SearchApi/SearchApi.Core/Adapters/Contracts/PersonSearchEvent.cs
@@ -6,6 +6,5 @@ namespace SearchApi.Core.Adapters.Contracts
     {
         Guid SearchRequestId { get; }
         DateTime TimeStamp { get; }
-        ProviderProfile ProviderProfile { get; }
     }
 }

--- a/app/SearchApi/SearchApi.Core/Adapters/Contracts/PersonSearchFailed.cs
+++ b/app/SearchApi/SearchApi.Core/Adapters/Contracts/PersonSearchFailed.cs
@@ -2,7 +2,7 @@
 
 namespace SearchApi.Core.Adapters.Contracts
 {
-    public interface PersonSearchFailed : PersonSearchEvent
+    public interface PersonSearchFailed : PersonSearchEvent, AdapterEvent
     {
         Exception Cause { get; }
     }

--- a/app/SearchApi/SearchApi.Core/Adapters/Contracts/PersonSearchOrdered.cs
+++ b/app/SearchApi/SearchApi.Core/Adapters/Contracts/PersonSearchOrdered.cs
@@ -1,0 +1,9 @@
+﻿using SearchApi.Core.Contracts;
+
+namespace SearchApi.Core.Adapters.Contracts
+{
+    public interface PersonSearchOrdered : PersonSearchEvent
+    {
+        ExecuteSearch ExecuteSearch { get; }
+    }
+}

--- a/app/SearchApi/SearchApi.Core/Adapters/Contracts/PersonSearchRejected.cs
+++ b/app/SearchApi/SearchApi.Core/Adapters/Contracts/PersonSearchRejected.cs
@@ -4,7 +4,7 @@ using SearchApi.Core.Adapters.Models;
 
 namespace SearchApi.Core.Adapters.Contracts
 {
-    public interface PersonSearchRejected : PersonSearchEvent
+    public interface PersonSearchRejected : PersonSearchEvent, AdapterEvent
     {
         IEnumerable<ValidationResult> Reasons { get; }
     }

--- a/app/SearchApi/SearchApi.Core/Adapters/Middleware/PersonSearchObserver.cs
+++ b/app/SearchApi/SearchApi.Core/Adapters/Middleware/PersonSearchObserver.cs
@@ -10,7 +10,7 @@ using SearchApi.Core.Contracts;
 
 namespace SearchApi.Core.Adapters.Middleware
 {
-    public class PersonSearchObserver : IConsumeMessageObserver<ExecuteSearch>
+    public class PersonSearchObserver : IConsumeMessageObserver<PersonSearchOrdered>
     {
 
         private readonly ProviderProfile _providerProfile;
@@ -22,24 +22,24 @@ namespace SearchApi.Core.Adapters.Middleware
             _providerProfile = providerProfile.Value;
         }
 
-        public async Task PreConsume(ConsumeContext<ExecuteSearch> context)
+        public async Task PreConsume(ConsumeContext<PersonSearchOrdered> context)
         {
             _logger.LogInformation($"Adapter {_providerProfile.Name} provider received new person search request.");
             await Task.FromResult(0);
             return;
         }
 
-        public async Task PostConsume(ConsumeContext<ExecuteSearch> context)
+        public async Task PostConsume(ConsumeContext<PersonSearchOrdered> context)
         {
             _logger.LogInformation($"Adapter {_providerProfile.Name} provider successfully processed new person search request.");
             await Task.FromResult(0);
             return;
         }
 
-        public async Task ConsumeFault(ConsumeContext<ExecuteSearch> context, Exception exception)
+        public async Task ConsumeFault(ConsumeContext<PersonSearchOrdered> context, Exception exception)
         {
             _logger.LogError(exception, "Adapter Failed to execute person search.");
-            await context.Publish<PersonSearchFailed>(new DefaultPersonSearchFailed(context.Message.Id,_providerProfile, exception));
+            await context.Publish<PersonSearchFailed>(new DefaultPersonSearchFailed(context.Message.SearchRequestId, _providerProfile, exception));
         }
     }
 }

--- a/app/SearchApi/SearchApi.Core/Contracts/ExecuteSearch.cs
+++ b/app/SearchApi/SearchApi.Core/Contracts/ExecuteSearch.cs
@@ -4,7 +4,6 @@ namespace SearchApi.Core.Contracts
 {
     public interface ExecuteSearch
     {
-        Guid Id { get; }
         string FirstName { get; }
         string LastName { get; }
         DateTime DateOfBirth { get; }

--- a/app/SearchApi/SearchApi.Web.Test/People/PeopleControllerTest.cs
+++ b/app/SearchApi/SearchApi.Web.Test/People/PeopleControllerTest.cs
@@ -8,6 +8,7 @@ using Moq;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
 using OpenTracing;
+using SearchApi.Core.Adapters.Contracts;
 using SearchApi.Core.Contracts;
 using SearchApi.Web.Controllers;
 
@@ -24,15 +25,12 @@ namespace SearchApi.Web.Test.People
 
         private readonly Mock<ILogger<PeopleController>> _loggerMock = new Mock<ILogger<PeopleController>>();
 
-        private Mock<ISendEndpoint> _sendEndpointMock;
-
         private Mock<IBusControl> _busControlMock;
 
             [SetUp]
         public void Init()
         {
             _busControlMock = new Mock<IBusControl>();
-            _sendEndpointMock = new Mock<ISendEndpoint>();
             _spanMock.Setup(x => x.SetTag(It.IsAny<string>(), It.IsAny<string>())).Returns(_spanMock.Object);
             _tracerMock.Setup(x => x.ActiveSpan).Returns(_spanMock.Object);
             _sut = new PeopleController(_busControlMock.Object, _loggerMock.Object, _tracerMock.Object);
@@ -47,7 +45,7 @@ namespace SearchApi.Web.Test.People
             Assert.IsInstanceOf<PersonSearchResponse>(result.Value);
             Assert.IsNotNull(((PersonSearchResponse)result.Value).Id);
             _spanMock.Verify(x => x.SetTag("searchRequestId", $"{((PersonSearchResponse)result.Value).Id}"), Times.Once);
-            _sendEndpointMock.Verify(x => x.Send(It.IsAny<ExecuteSearch>(), It.IsAny<CancellationToken>()), Times.Once);
+            _busControlMock.Verify(x => x.Publish(It.IsAny<PersonSearchOrdered>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [Test]
@@ -60,7 +58,7 @@ namespace SearchApi.Web.Test.People
             Assert.IsInstanceOf<PersonSearchResponse>(result.Value);
             Assert.AreEqual( expectedId, ((PersonSearchResponse)result.Value).Id);
             _spanMock.Verify(x => x.SetTag("searchRequestId", $"{((PersonSearchResponse)result.Value).Id}"), Times.Once);
-            _sendEndpointMock.Verify(x => x.Send(It.IsAny<ExecuteSearch>(), It.IsAny<CancellationToken>()), Times.Once);
+            _busControlMock.Verify(x => x.Publish(It.IsAny<PersonSearchOrdered>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
     }

--- a/app/SearchApi/SearchApi.Web.Test/People/PeopleControllerTest.cs
+++ b/app/SearchApi/SearchApi.Web.Test/People/PeopleControllerTest.cs
@@ -26,17 +26,16 @@ namespace SearchApi.Web.Test.People
 
         private Mock<ISendEndpoint> _sendEndpointMock;
 
-        private readonly Mock<ISendEndpointProvider> _sendEndPointProviderMock = new Mock<ISendEndpointProvider>();
+        private Mock<IBusControl> _busControlMock;
 
             [SetUp]
         public void Init()
         {
+            _busControlMock = new Mock<IBusControl>();
             _sendEndpointMock = new Mock<ISendEndpoint>();
-            EndpointConvention.Map<ExecuteSearch>(new Uri("http://random"));
-            _sendEndPointProviderMock.Setup(x => x.GetSendEndpoint(It.IsAny<Uri>())).Returns(Task.FromResult(_sendEndpointMock.Object));
             _spanMock.Setup(x => x.SetTag(It.IsAny<string>(), It.IsAny<string>())).Returns(_spanMock.Object);
             _tracerMock.Setup(x => x.ActiveSpan).Returns(_spanMock.Object);
-            _sut = new PeopleController(_sendEndPointProviderMock.Object, _loggerMock.Object, _tracerMock.Object);
+            _sut = new PeopleController(_busControlMock.Object, _loggerMock.Object, _tracerMock.Object);
         }
 
 

--- a/app/SearchApi/SearchApi.Web/Startup.cs
+++ b/app/SearchApi/SearchApi.Web/Startup.cs
@@ -170,9 +170,6 @@ namespace SearchApi.Web
             var rabbitMqSettings = Configuration.GetSection("RabbitMq").Get<RabbitMqConfiguration>();
             var rabbitBaseUri = $"amqp://{rabbitMqSettings.Host}:{rabbitMqSettings.Port}";
 
-            // Globally configure Execute Search Endpoint
-            EndpointConvention.Map<ExecuteSearch>(new Uri($"{rabbitBaseUri}/{nameof(ExecuteSearch)}"));
-
             services.AddMassTransit(x =>
             {
                 // Add RabbitMq Service Bus


### PR DESCRIPTION
# Description

This PR includes the following change:

- Send a `PersonSearchOrdered` event for the adapters to consume
- Consume `PersonSearchOrdered` on the SearchAdapters

Architecture Change:
![image](https://user-images.githubusercontent.com/51387119/69746437-1f860780-10f9-11ea-878c-62b8a3bfd79f.png)


## Type of change
.
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## For bcgov contributors:

this PR fixes jira ticket: **FAMS3-770**
