### PR TITLE
SearchApi should expose Enum as String not int

### DIFF
--- a/app/SearchApi/SearchApi.Web/People/Identifier.cs
+++ b/app/SearchApi/SearchApi.Web/People/Identifier.cs
@@ -20,7 +20,7 @@ namespace SearchApi.Web.People
         public DateTime? ExpirationDate { get; set; }
 
         [Description("The identfication type,such as driver license.")]
-        public IdentifierTypeEnum Type { get; set; }
+        public IdentifierType Type { get; set; }
 
         [Description("The identifier is issued by who or which organization.")]
         public string IssuedBy { get; set; }

--- a/app/SearchApi/SearchApi.Web/People/IdentifierType.cs
+++ b/app/SearchApi/SearchApi.Web/People/IdentifierType.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace SearchApi.Web.People
 {
-    public enum IdentifierTypeEnum
+    public enum IdentifierType
     {
         DriverLicense,
         SocialInsuranceNumber,

--- a/app/SearchApi/SearchApi.Web/People/IdentifierTypeEnum.cs
+++ b/app/SearchApi/SearchApi.Web/People/IdentifierTypeEnum.cs
@@ -7,16 +7,15 @@ namespace SearchApi.Web.People
 {
     public enum IdentifierTypeEnum
     {
-        None = 0,
-        DriverLicense = 1,
-        SocialInsuranceNumber = 2,
-        PersonalHealthNumber = 3,
-        BirthCertificate = 4,
-        CorrectionsId = 5,
-        NativeStatusCard = 6,
-        Passport = 7,
-        WcbClaim = 8,
-        Other = 9,
-        SecurityKeyword = 10
+        DriverLicense,
+        SocialInsuranceNumber,
+        PersonalHealthNumber,
+        BirthCertificate,
+        CorrectionsId,
+        NativeStatusCard,
+        Passport,
+        WcbClaim,
+        Other,
+        SecurityKeyword
     }
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed changes:

- remove int value of the enum for improving swagger documentation

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Locally

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## For bcgov contributors:

this PR fixes jira ticket: **FAMS3-803**
