### PR TITLE
Remove EventName from webHooks Configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ To enable Person Search notification, configure the SearchApi WebHooks settings.
     "WebHooks": [
       {
         "Name": "dynadapter",
-        "Uri":  "http://localhost:5000",
+        "Uri":  "http://localhost:5000/PersonSearch",
       }
     ] 
   }

--- a/README.md
+++ b/README.md
@@ -55,17 +55,27 @@ Configure RabbiMq using the following ENV variables:
 
 If the WebHooks section is configured, SearchApi automatically posts a new notification into the webhook collection. The WebHook configuraton in SearchApi is
 
+To enable Person Search notification, configure the SearchApi WebHooks settings.
+
 ```json
 "SearchApi": {
     "WebHooks": [
       {
         "Name": "dynadapter",
-        "Uri":  "http://localhost:5000/PersonSearch",
-        "EventName" : "PersonSearch"
+        "Uri":  "http://localhost:5000",
       }
     ] 
   }
 ```
+
+Search Api Post events to the following routes schema host/PersonSearch/{event}/{searchRequestId}.
+
+| --- | --- | --- |
+| Event | URL | Description |
+| Completed | host/PersonSearch/Completed/{searchRequestId} | Occurs when an adapter has completed a search. the payload might contains additional information ont the person |
+| Accepted | host/PersonSearch/Accepted/{searchRequestId} | Occurs when an adapter has accepted a search |
+| Rejected | host/PersonSearch/Rejected/{searchRequestId} | Occurs when an adapter has rejected a search |
+| Failed | host/PersonSearch/Failed/{searchRequestId} | Occurs when an adapter has failed on executing a search |
 
 With this configuration the searchApi will post Event to `http://localhost:5000/PersonSearch/{EventName}/{id}` where {id} is a global unique identifier for the search request . the content of the payload is  dependent on the event.
 

--- a/app/SearchApi/SearchApi.Web.Test/Configuration/SearchApiOptionsTest.cs
+++ b/app/SearchApi/SearchApi.Web.Test/Configuration/SearchApiOptionsTest.cs
@@ -10,11 +10,10 @@ namespace SearchApi.Web.Test.Configuration
         public void Should_add_a_new_webHook()
         {
 
-            var options = new SearchApiOptions().AddWebHook("test", "http://example.com/post","MatchFound");
+            var options = new SearchApiOptions().AddWebHook("test", "http://example.com/post");
 
             Assert.AreEqual(1, options.WebHooks.Count);
             Assert.AreEqual("test", options.WebHooks.FirstOrDefault().Name);
-            Assert.AreEqual(true, options.WebHooks.FirstOrDefault().EventName.Contains("MatchFound"));
             Assert.AreEqual("http://example.com/post", options.WebHooks.FirstOrDefault().Uri);
 
         }

--- a/app/SearchApi/SearchApi.Web.Test/Notifications/WebHookNotifierSearchStatusTest.cs
+++ b/app/SearchApi/SearchApi.Web.Test/Notifications/WebHookNotifierSearchStatusTest.cs
@@ -53,7 +53,7 @@ namespace SearchApi.Web.Test.Notifications
             public async Task it_should_send_notification_to_one_subscribers()
             {
 
-                _searchApiOptionsMock.Setup(x => x.Value).Returns(new SearchApiOptions().AddWebHook("test", "http://test:1234", "PersonSearch"));
+                _searchApiOptionsMock.Setup(x => x.Value).Returns(new SearchApiOptions().AddWebHook("test", "http://test:1234"));
 
                 var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
                 handlerMock
@@ -98,7 +98,7 @@ namespace SearchApi.Web.Test.Notifications
             {
 
 
-                _searchApiOptionsMock.Setup(x => x.Value).Returns(new SearchApiOptions().AddWebHook("test", "http://test:1234/Event", "PersonSearch"));
+                _searchApiOptionsMock.Setup(x => x.Value).Returns(new SearchApiOptions().AddWebHook("test", "http://test:1234/Event"));
 
                 var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
                 handlerMock
@@ -145,8 +145,8 @@ namespace SearchApi.Web.Test.Notifications
 
 
                 _searchApiOptionsMock.Setup(x => x.Value).Returns(new SearchApiOptions()
-                    .AddWebHook("test", "http://test:1234", "PersonSearch")
-                    .AddWebHook("test2", "http://test:5678", "PersonSearch"));
+                    .AddWebHook("test", "http://test:1234")
+                    .AddWebHook("test2", "http://test:5678"));
 
                 var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
                 handlerMock
@@ -206,7 +206,7 @@ namespace SearchApi.Web.Test.Notifications
                 var fakeMatchFound = new FakePersonFound();
 
                 _searchApiOptionsMock.Setup(x => x.Value).Returns(new SearchApiOptions()
-                    .AddWebHook("test", "not_uri", "PersonSearch"));
+                    .AddWebHook("test", "not_uri"));
 
                 var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
                 handlerMock
@@ -239,7 +239,7 @@ namespace SearchApi.Web.Test.Notifications
             {
 
 
-                _searchApiOptionsMock.Setup(x => x.Value).Returns(new SearchApiOptions().AddWebHook("test", "http://test:1234", "PersonSearch"));
+                _searchApiOptionsMock.Setup(x => x.Value).Returns(new SearchApiOptions().AddWebHook("test", "http://test:1234"));
 
                 var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
                 handlerMock
@@ -284,7 +284,7 @@ namespace SearchApi.Web.Test.Notifications
             {
 
 
-                _searchApiOptionsMock.Setup(x => x.Value).Returns(new SearchApiOptions().AddWebHook("test", "http://test:1234", "PersonSearch"));
+                _searchApiOptionsMock.Setup(x => x.Value).Returns(new SearchApiOptions().AddWebHook("test", "http://test:1234"));
 
                 var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
                 handlerMock
@@ -329,7 +329,7 @@ namespace SearchApi.Web.Test.Notifications
             {
 
 
-                _searchApiOptionsMock.Setup(x => x.Value).Returns(new SearchApiOptions().AddWebHook("test", "http://test:1234", "PersonSearch"));
+                _searchApiOptionsMock.Setup(x => x.Value).Returns(new SearchApiOptions().AddWebHook("test", "http://test:1234"));
 
                 var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
                 handlerMock

--- a/app/SearchApi/SearchApi.Web/Configuration/SearchApiOptions.cs
+++ b/app/SearchApi/SearchApi.Web/Configuration/SearchApiOptions.cs
@@ -9,14 +9,12 @@ namespace SearchApi.Web.Configuration
     {
         public List<WebHookNotification> WebHooks { get; set; } = new List<WebHookNotification>();
 
-        public SearchApiOptions AddWebHook(string name, string uri, string eventName)
+        public SearchApiOptions AddWebHook(string name, string uri)
         {
             WebHooks.Add(new WebHookNotification()
             {
                 Name = name,
                 Uri = uri,
-                EventName = eventName
-
             });
             return this;
         }
@@ -30,7 +28,6 @@ namespace SearchApi.Web.Configuration
     {
         public string Name { get; set; }
         public string Uri { get; set; }
-        public string EventName { get; set; }
     }
 
 }

--- a/app/SearchApi/SearchApi.Web/appsettings.json
+++ b/app/SearchApi/SearchApi.Web/appsettings.json
@@ -16,16 +16,9 @@
   "SearchApi": {
     "WebHooks": [
       {
-        "Name": "DynaAdapter",
-        "Uri": "http://localhost:5000",
-        "Event": "PersonFound"
-      },
-      {
-        "Name": "DynaAdapter",
-        "Uri": "http://localhost:5000",
-        "Event": "PersonSearch"
+        "Name": "DynAdapter",
+        "Uri": "http://localhost:5000"
       }
-
     ] 
   } 
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,6 @@ services:
       JAEGER_ENDPOINT: http://jaeger-collector:14268/api/traces
       SearchApi__WebHooks__0__Name: dynadapter
       SearchApi__WebHooks__0__Uri: http://dynadapter/PersonSearch
-      SearchApi__WebHooks__0__EventName: MatchFound
     ports:
       - "5050:80"
     restart: always


### PR DESCRIPTION
# Description

This PR includes the following proposed change:

- Removing the Event from the webHook configuration as not in use.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## For bcgov contributors:

this PR fixes jira ticket: **FAMS3-840**
