### PR TITLE
Process completed event in PersonSearch controller for dynaAdaptor

### DIFF
--- a/app/DynamicsAdapter/DynamicsAdapter.Web.Test/PersonSearch/PersonSearchControllerTest.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web.Test/PersonSearch/PersonSearchControllerTest.cs
@@ -72,44 +72,70 @@ namespace DynamicsAdapter.Web.Test.PersonSearch
         }
 
         [Test]
-        public async Task With_valid_match_found_data_should_return_ok()
+        public async Task With_valid_completed_event_it_should_return_ok()
         {
-            var result = await _sut.MatchFound(_testGuid, new MatchFound()
-            {
-                PersonIds = new List<PersonId>()
+            var result = await _sut.Completed(_testGuid, new PersonSearchController.PersonCompletedEvent()
                 {
-                    new PersonId()
+                    SearchRequestId = Guid.NewGuid(),
+                    TimeStamp = DateTime.Now,
+                    ProviderProfile = new PersonSearchController.ProviderProfile()
                     {
-                        Issuer = "test",
-                        Number = "test",
-                        Kind = PersonIDKind.DriverLicense
-                    }
+                        Name = "TEST PROVIDER"
+                    },
+                    MatchFound = new MatchFound()
+                    {
+                        SearchRequestId = Guid.NewGuid(),
+                        Person = new Person() { },
+                        PersonIds = new List<PersonId>()
+                        {
+                            new PersonId()
+                            {
+                                Issuer = "test",
+                                Number = "test",
+                                Kind = PersonIDKind.DriverLicense
+                            }
+                        }
+                    } 
                 }
-            });
+            );
+            _searchRequestServiceMock
+                .Verify(x => x.UploadIdentifier(It.IsAny<SSG_Identifier>(), It.IsAny<CancellationToken>()), Times.Once);
+            _searchApiRequestServiceMock
+                .Verify(x => x.AddEventAsync(It.Is<Guid>(x => x == _testGuid), It.IsAny<SSG_SearchApiEvent>(), It.IsAny<CancellationToken>()), Times.Once);
             Assert.IsInstanceOf(typeof(OkResult), result);
-
         }
 
         [Test]
-        public async Task With_exception_match_found_data_should_return_badrequest()
+        public async Task With_exception_completed_event_should_return_badrequest()
         {
-            var result = await _sut.MatchFound(_exceptionGuid, new MatchFound()
+            var result = await _sut.Completed(_exceptionGuid, new PersonSearchController.PersonCompletedEvent()
             {
-                PersonIds = new List<PersonId>()
+                SearchRequestId = Guid.NewGuid(),
+                TimeStamp = DateTime.Now,
+                ProviderProfile = new PersonSearchController.ProviderProfile()
                 {
-                    new PersonId()
-                    {
-                        Issuer = "test",
-                        Number = "test",
-                        Kind = PersonIDKind.DriverLicense
-                    }
+                    Name = "TEST PROVIDER"
+                },
+                MatchFound = new MatchFound()
+                {
+                    SearchRequestId = Guid.NewGuid(),
+                    Person = new Person() { },
+                    PersonIds = new List<PersonId>()
+                        {
+                            new PersonId()
+                            {
+                                Issuer = "exception",
+                                Number = "exception",
+                                Kind = PersonIDKind.DriverLicense
+                            }
+                        }
                 }
             });
             Assert.IsInstanceOf(typeof(BadRequestResult), result);
         }
 
         [Test]
-        public async Task With_valid_event_it_should_return_ok()
+        public async Task With_valid_accepted_event_it_should_return_ok()
         {
             var result = await _sut.Accepted(_testGuid, new PersonSearchController.PersonAcceptedEvent()
             {


### PR DESCRIPTION
# Description

This is to process Person Search Completed event sent from searchApi.
We ignore payload right now. Will deal with correct payload in another pr.

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

tested locally and connected to dynamic dev server.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## For bcgov contributors:

this PR fixes jira ticket: FAMS-823
