### PR TITLE
Adding support for basePath + QueryString apiGatewayHandler

### DIFF
--- a/app/DynamicsAdapter/DynamicsAdapter.Web.Test/ApiGateway/ApiGatewayHandlerTest.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web.Test/ApiGateway/ApiGatewayHandlerTest.cs
@@ -201,4 +201,91 @@ namespace DynamicsAdapter.Web.Test.ApiGateway
             var result = await invoker.SendAsync(httpRequestMessage, new CancellationToken());
         }
     }
+
+    public class WithApiGatewayUrlAndQueryStringConfiguration
+    {
+
+        private ApiGatewayHandler _sut;
+        private Mock<IOptions<ApiGatewayOptions>> _apiGatewayOptionsMock;
+
+        [SetUp]
+        public void SetUp()
+        {
+
+            _apiGatewayOptionsMock = new Mock<IOptions<ApiGatewayOptions>>();
+
+            _apiGatewayOptionsMock.Setup(x => x.Value).Returns(new ApiGatewayOptions()
+            {
+                BasePath = "http://apigateway"
+            });
+
+            _sut = new ApiGatewayHandler(_apiGatewayOptionsMock.Object)
+            {
+                InnerHandler = new TestHandler()
+            };
+        }
+
+        public class TestHandler : DelegatingHandler
+        {
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+                CancellationToken cancellationToken)
+            {
+                Assert.AreEqual("http://apigateway/path?test=test", request.RequestUri.AbsoluteUri);
+                return await Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+            }
+        }
+
+        [Test]
+        public async Task Execute()
+        {
+            // in your test class method
+            var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "http://foo.com/path?test=test");
+            var invoker = new HttpMessageInvoker(_sut);
+            var result = await invoker.SendAsync(httpRequestMessage, new CancellationToken());
+        }
+    }
+
+
+    public class WithApiGatewayUrlWithPathAndQueryStringConfiguration
+    {
+
+        private ApiGatewayHandler _sut;
+        private Mock<IOptions<ApiGatewayOptions>> _apiGatewayOptionsMock;
+
+        [SetUp]
+        public void SetUp()
+        {
+
+            _apiGatewayOptionsMock = new Mock<IOptions<ApiGatewayOptions>>();
+
+            _apiGatewayOptionsMock.Setup(x => x.Value).Returns(new ApiGatewayOptions()
+            {
+                BasePath = "http://apigateway/test"
+            });
+
+            _sut = new ApiGatewayHandler(_apiGatewayOptionsMock.Object)
+            {
+                InnerHandler = new TestHandler()
+            };
+        }
+
+        public class TestHandler : DelegatingHandler
+        {
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+                CancellationToken cancellationToken)
+            {
+                Assert.AreEqual("http://apigateway/test/path?test=test", request.RequestUri.AbsoluteUri);
+                return await Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+            }
+        }
+
+        [Test]
+        public async Task Execute()
+        {
+            // in your test class method
+            var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "http://foo.com/path?test=test");
+            var invoker = new HttpMessageInvoker(_sut);
+            var result = await invoker.SendAsync(httpRequestMessage, new CancellationToken());
+        }
+    }
 }

--- a/app/DynamicsAdapter/DynamicsAdapter.Web.Test/ApiGateway/ApiGatewayHandlerTest.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web.Test/ApiGateway/ApiGatewayHandlerTest.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
 using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
@@ -144,6 +145,58 @@ namespace DynamicsAdapter.Web.Test.ApiGateway
         {
             // in your test class method
             var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "http://foo.com/test");
+            var invoker = new HttpMessageInvoker(_sut);
+            var result = await invoker.SendAsync(httpRequestMessage, new CancellationToken());
+        }
+    }
+
+
+    public class WithApiGatewayBasePathWithPathConfiguration
+    {
+
+        private ApiGatewayHandler _sut;
+        private Mock<IOptions<ApiGatewayOptions>> _apiGatewayOptionsMock;
+
+        [SetUp]
+        public void SetUp()
+        {
+
+            _apiGatewayOptionsMock = new Mock<IOptions<ApiGatewayOptions>>();
+
+            _apiGatewayOptionsMock.Setup(x => x.Value).Returns(new ApiGatewayOptions()
+            {
+                BasePath = "http://test/path/"
+            });
+
+            _sut = new ApiGatewayHandler(_apiGatewayOptionsMock.Object)
+            {
+                InnerHandler = new TestHandler()
+            };
+        }
+
+        public class TestHandler : DelegatingHandler
+        {
+            protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request,
+                CancellationToken cancellationToken)
+            {
+                Assert.AreEqual("http://test/path/somepath", request.RequestUri.AbsoluteUri);
+                return await Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK));
+            }
+        }
+
+        [Test]
+        public async Task Execute()
+        {
+
+            if (Uri.TryCreate(new Uri("http://test/path/"), "/somepath", out var a))
+            {
+                Console.WriteLine(a);
+            }
+
+            var test = new Uri("http://test/path/", UriKind.Absolute);
+
+            // in your test class method
+            var httpRequestMessage = new HttpRequestMessage(HttpMethod.Get, "http://foo.com/somepath");
             var invoker = new HttpMessageInvoker(_sut);
             var result = await invoker.SendAsync(httpRequestMessage, new CancellationToken());
         }

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/ApiGateway/ApiGatewayHandler.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/ApiGateway/ApiGatewayHandler.cs
@@ -24,7 +24,9 @@ namespace DynamicsAdapter.Web.ApiGateway
         {
             if(string.IsNullOrEmpty(_apiGatewayOptions.BasePath)) return await base.SendAsync(request, cancellationToken);
 
-            if (Uri.TryCreate(CombineUrls(_apiGatewayOptions.BasePath, request.RequestUri.AbsolutePath),  UriKind.Absolute, out var path))
+
+
+            if (Uri.TryCreate(CombineUrls(_apiGatewayOptions.BasePath, request.RequestUri.PathAndQuery),  UriKind.Absolute, out var path))
             {
                 request.RequestUri = path;
             }

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/ApiGateway/ApiGatewayHandler.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/ApiGateway/ApiGatewayHandler.cs
@@ -24,8 +24,27 @@ namespace DynamicsAdapter.Web.ApiGateway
         {
             if(string.IsNullOrEmpty(_apiGatewayOptions.BasePath)) return await base.SendAsync(request, cancellationToken);
 
-            request.RequestUri = new Uri(new Uri(_apiGatewayOptions.BasePath), request.RequestUri.AbsolutePath);
+            if (Uri.TryCreate(CombineUrls(_apiGatewayOptions.BasePath, request.RequestUri.AbsolutePath),  UriKind.Absolute, out var path))
+            {
+                request.RequestUri = path;
+            }
+            
             return await base.SendAsync(request, cancellationToken);
+        }
+
+
+        public static string CombineUrls(string baseUrl, string relativeUrl)
+        {
+            if (string.IsNullOrWhiteSpace(baseUrl))
+                throw new ArgumentNullException(nameof(baseUrl));
+
+            if (string.IsNullOrWhiteSpace(relativeUrl))
+                return baseUrl;
+
+            baseUrl = baseUrl.TrimEnd('/');
+            relativeUrl = relativeUrl.TrimStart('/');
+
+            return $"{baseUrl}/{relativeUrl}";
         }
     }
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change:

- Adding support for QueryString and path for the ApiGatewayHandler

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Local Docker  + Unit Tests

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## For bcgov contributors:

this PR fixes jira ticket: **FAMS3-880**
