### PR TITLE
DynAdapter can map the returned suppliedBy to sourceText in ssg_identifier.

### DIFF
--- a/app/DynamicsAdapter/DynamicsAdapter.Web/SearchRequest/SearchRequestAutoMapperProfile.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/SearchRequest/SearchRequestAutoMapperProfile.cs
@@ -89,7 +89,8 @@ namespace DynamicsAdapter.Web.SearchRequest
     {
         public int? Convert(string source, ResolutionContext context)
         {
-            return Enumeration.GetAll<InformationSourceType>().FirstOrDefault(m => m.Name.Equals(source, StringComparison.OrdinalIgnoreCase))?.Value;
+            InformationSourceType sourceType = Enumeration.GetAll<InformationSourceType>().FirstOrDefault(m => m.Name.Equals(source, StringComparison.OrdinalIgnoreCase));
+            return (sourceType==null)? InformationSourceType.Other.Value: sourceType.Value;
         }
     }
 

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/SearchRequest/SearchRequestAutoMapperProfile.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/SearchRequest/SearchRequestAutoMapperProfile.cs
@@ -22,7 +22,7 @@ namespace DynamicsAdapter.Web.SearchRequest
                  .ForMember(dest => dest.EffectiveDate, opt => opt.MapFrom(src => src.IdentificationEffectiveDate))
                  .ForMember(dest => dest.ExpirationDate, opt => opt.MapFrom(src => src.IdentificationExpirationDate))
                  .ForMember(dest => dest.Type, opt => opt.ConvertUsing(new IdentifierTypeConverter(), src => src.IdentifierType))
-                 .ForMember(dest => dest.IssuedBy, opt => opt.ConvertUsing(new IssueByTypeConverter(), src => src.InformationSource));
+                 .ForMember(dest => dest.IssuedBy, opt => opt.ConvertUsing(new InformationSourceConverter(), src => src.InformationSource));
 
             CreateMap<SSG_SearchApiRequest, PersonSearchRequest>()
                  .ForMember(dest => dest.FirstName, opt => opt.MapFrom(src => src.PersonGivenName))
@@ -71,19 +71,28 @@ namespace DynamicsAdapter.Web.SearchRequest
                  .ForMember(dest => dest.IdentificationEffectiveDate, opt => opt.MapFrom(src => src.EffectiveDate))
                  .ForMember(dest => dest.IdentificationExpirationDate, opt => opt.MapFrom(src => src.ExpirationDate))
                  .ForMember(dest => dest.IdentifierType, opt => opt.ConvertUsing(new PersonalIdentifierTypeConverter(), src => src.Type))
-                 .ForMember(dest => dest.IssuedBy, opt => opt.MapFrom(src => src.IssuedBy))
+                 .ForMember(dest => dest.InformationSource, opt => opt.ConvertUsing(new IssuedByTypeConverter(), src=>src.IssuedBy))
                  .ForMember(dest => dest.StateCode, opt => opt.MapFrom(src => 0))
                  .ForMember(dest => dest.StatusCode, opt => opt.MapFrom(src => 1));
         }
     }
 
-    public class IssueByTypeConverter : IValueConverter<int?, string>
+    public class InformationSourceConverter : IValueConverter<int?, string>
     {
         public string Convert(int? source, ResolutionContext context)
         {
             return Enumeration.GetAll<InformationSourceType>().FirstOrDefault(m => m.Value == source)?.Name;
         }
     }
+
+    public class IssuedByTypeConverter : IValueConverter<string, int?>
+    {
+        public int? Convert(string source, ResolutionContext context)
+        {
+            return Enumeration.GetAll<InformationSourceType>().FirstOrDefault(m => m.Name == source)?.Value;
+        }
+    }
+
     public class IdentifierTypeConverter : IValueConverter<int?, int?>
     {
         public int? Convert(int? source, ResolutionContext context)

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/SearchRequest/SearchRequestAutoMapperProfile.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/SearchRequest/SearchRequestAutoMapperProfile.cs
@@ -89,7 +89,7 @@ namespace DynamicsAdapter.Web.SearchRequest
     {
         public int? Convert(string source, ResolutionContext context)
         {
-            return Enumeration.GetAll<InformationSourceType>().FirstOrDefault(m => m.Name == source)?.Value;
+            return Enumeration.GetAll<InformationSourceType>().FirstOrDefault(m => m.Name.Equals(source, StringComparison.OrdinalIgnoreCase))?.Value;
         }
     }
 

--- a/app/SearchApi/SearchAdapter.Sample/SearchRequest/SearchRequestConsumer.cs
+++ b/app/SearchApi/SearchAdapter.Sample/SearchRequest/SearchRequestConsumer.cs
@@ -100,7 +100,7 @@ namespace SearchAdapter.Sample.SearchRequest
                             Type = PersonalIdentifierType.DriverLicense,
                             EffectiveDate = DateTime.Now.AddDays(-365),
                             ExpirationDate = DateTime.Now.AddDays(365),
-                            IssuedBy = "British Columbia",
+                            IssuedBy = "ICBC",
                             SerialNumber = new Random().Next(0, 50000).ToString()
                         }
                     }


### PR DESCRIPTION
# Description

DynAdapter can map the returned suppliedBy to sourceText in ssg_identifier.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
tested on local machine

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## For bcgov contributors:

this PR fixes jira ticket: FAMS-885
