### PR TITLE
dynAdaptor should use auto generated json api spec.

### DIFF
--- a/app/DynamicsAdapter/DynamicsAdapter.Web.Test/Mapping/MappingProfileTest.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web.Test/Mapping/MappingProfileTest.cs
@@ -207,7 +207,7 @@ namespace DynamicsAdapter.Web.Test.Mapping
                     FirstName = "firstName",
                     LastName = "lastName",
                     DateOfBirth = new DateTime(2019, 3, 5),
-                    Identifiers = new PersonalIdentifier[]
+                    Identifiers = new PersonalIdentifierConcrete[]
                     {
                         new PersonalIdentifierConcrete(){ },
                         new PersonalIdentifierConcrete(){ }
@@ -243,7 +243,7 @@ namespace DynamicsAdapter.Web.Test.Mapping
                     FirstName = "firstName",
                     LastName = "lastName",
                     DateOfBirth = new DateTime(2019, 3, 5),
-                    Identifiers = new PersonalIdentifier[]
+                    Identifiers = new PersonalIdentifierConcrete[]
                     {
                         new PersonalIdentifierConcrete(){ },
                         new PersonalIdentifierConcrete(){ }

--- a/app/DynamicsAdapter/DynamicsAdapter.Web.Test/Mapping/MappingProfileTest.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web.Test/Mapping/MappingProfileTest.cs
@@ -31,7 +31,7 @@ namespace DynamicsAdapter.Web.Test.Mapping
         }
 
         [Test]
-        public void SSG_Identifier_should_map_to_Identifier_correctly()
+        public void SSG_Identifier_should_map_to_PersonalIdentifier_correctly()
         {
             SSG_Identifier sSG_Identifier = new SSG_Identifier()
             {
@@ -42,11 +42,11 @@ namespace DynamicsAdapter.Web.Test.Mapping
                 InformationSource = InformationSourceType.Employer.Value
 
             };
-            Identifier identifier = _mapper.Map<Identifier>(sSG_Identifier);
+            PersonalIdentifier identifier = _mapper.Map<PersonalIdentifier>(sSG_Identifier);
             Assert.AreEqual("testIdentification", identifier.SerialNumber);
-            Assert.AreEqual(new DateTime(2001, 1, 1), identifier.EffectiveDate);
+            Assert.AreEqual(new DateTimeOffset(new DateTime(2001, 1, 1)), identifier.EffectiveDate);
             Assert.AreEqual(new DateTimeOffset(new DateTime(2001, 1, 1)), identifier.ExpirationDate);
-            Assert.AreEqual((int)PersonalIdentifierType.SocialInsuranceNumber, identifier.Type);
+            Assert.AreEqual(PersonalIdentifierType.SocialInsuranceNumber, identifier.Type);
             Assert.AreEqual(InformationSourceType.Employer.Name, identifier.IssuedBy);
         }
 
@@ -209,8 +209,8 @@ namespace DynamicsAdapter.Web.Test.Mapping
                     DateOfBirth = new DateTime(2019, 3, 5),
                     Identifiers = new PersonalIdentifier[]
                     {
-                        new PersonalIdentifier(){ },
-                        new PersonalIdentifier(){ }
+                        new PersonalIdentifierConcrete(){ },
+                        new PersonalIdentifierConcrete(){ }
                     },
                     Addresses = new Address[]
                     {
@@ -245,8 +245,8 @@ namespace DynamicsAdapter.Web.Test.Mapping
                     DateOfBirth = new DateTime(2019, 3, 5),
                     Identifiers = new PersonalIdentifier[]
                     {
-                        new PersonalIdentifier(){ },
-                        new PersonalIdentifier(){ }
+                        new PersonalIdentifierConcrete(){ },
+                        new PersonalIdentifierConcrete(){ }
                     },
                     Addresses = null
                 }
@@ -262,11 +262,11 @@ namespace DynamicsAdapter.Web.Test.Mapping
         [Test]
         public void PersonalIdentifier_should_map_to_SSG_Identifier_correctly()
         {
-            PersonalIdentifier identifier = new PersonalIdentifier()
+            PersonalIdentifier identifier = new PersonalIdentifierConcrete()
             {
                 SerialNumber = "1111111",
-                ExpirationDate = new DateTime(2003, 3, 3),
-                EffectiveDate = new DateTime(2002, 2, 2),
+                ExpirationDate = new DateTimeOffset(new DateTime(2003, 3, 3)),
+                EffectiveDate = new DateTimeOffset(new DateTime(2002, 2, 2)),
                 Type = PersonalIdentifierType.DriverLicense,
                 IssuedBy = "ICBC"
             };

--- a/app/DynamicsAdapter/DynamicsAdapter.Web.Test/PersonSearch/PersonSearchControllerTest.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web.Test/PersonSearch/PersonSearchControllerTest.cs
@@ -90,7 +90,7 @@ namespace DynamicsAdapter.Web.Test.PersonSearch
                     DateOfBirth = DateTime.Now,
                     FirstName = "TEST1",
                     LastName = "TEST2",
-                    Identifiers = new List<PersonalIdentifier>()
+                    Identifiers = new List<PersonalIdentifierConcrete>()
                         {
                             new PersonalIdentifierConcrete()
                             {

--- a/app/DynamicsAdapter/DynamicsAdapter.Web.Test/PersonSearch/PersonSearchControllerTest.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web.Test/PersonSearch/PersonSearchControllerTest.cs
@@ -92,7 +92,7 @@ namespace DynamicsAdapter.Web.Test.PersonSearch
                     LastName = "TEST2",
                     Identifiers = new List<PersonalIdentifier>()
                         {
-                            new PersonalIdentifier()
+                            new PersonalIdentifierConcrete()
                             {
                                SerialNumber  = "test",
                                IssuedBy = "test",

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/Mapping/Converters.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/Mapping/Converters.cs
@@ -43,11 +43,11 @@ namespace DynamicsAdapter.Web.Mapping
         };
     }
 
-    public class IdentifierTypeConverter : IValueConverter<int?, int?>
+    public class IdentifierTypeConverter : IValueConverter<int?, PersonalIdentifierType>
     {      
-        public int? Convert(int? source, ResolutionContext context)
+        public PersonalIdentifierType Convert(int? source, ResolutionContext context)
         {
-            return source==null? null : (int?)IDType.IDTypeDictionary[(int)source];
+            return source==null? PersonalIdentifierType.Other : IDType.IDTypeDictionary[(int)source];
         }
     }
 
@@ -72,6 +72,14 @@ namespace DynamicsAdapter.Web.Mapping
         public int? Convert(string source, ResolutionContext context)
         {
             return Enumeration.GetAll<LocationType>().FirstOrDefault(m => m.Name.Equals(source, StringComparison.OrdinalIgnoreCase))?.Value;
+        }
+    }
+
+    public class DateTimeOffsetConverter : IValueConverter<DateTimeOffset?, DateTime?>
+    {
+        public DateTime? Convert(DateTimeOffset? source, ResolutionContext context)
+        {
+            return source ==null? null : (DateTime?)(((DateTimeOffset)source).DateTime);
         }
     }
 

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/Mapping/MappingProfile.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/Mapping/MappingProfile.cs
@@ -15,10 +15,10 @@ namespace  DynamicsAdapter.Web.Mapping
 
     public class MappingProfile : Profile
     {
-
         public MappingProfile()
         {
-            CreateMap<SSG_Identifier, Identifier>()
+            CreateMap<SSG_Identifier, PersonalIdentifier>()
+                 .ConstructUsing( m => new PersonalIdentifierConcrete(){})
                  .ForMember(dest => dest.SerialNumber, opt => opt.MapFrom(src => src.Identification))
                  .ForMember(dest => dest.EffectiveDate, opt => opt.MapFrom(src => src.IdentificationEffectiveDate))
                  .ForMember(dest => dest.ExpirationDate, opt => opt.MapFrom(src => src.IdentificationExpirationDate))
@@ -87,10 +87,10 @@ namespace  DynamicsAdapter.Web.Mapping
 
             CreateMap<PersonalIdentifier, SSG_Identifier>()
                  .ForMember(dest => dest.Identification, opt => opt.MapFrom(src => src.SerialNumber))
-                 .ForMember(dest => dest.IdentificationEffectiveDate, opt => opt.MapFrom(src => src.EffectiveDate))
-                 .ForMember(dest => dest.IdentificationExpirationDate, opt => opt.MapFrom(src => src.ExpirationDate))
+                 .ForMember(dest => dest.IdentificationEffectiveDate, opt => opt.ConvertUsing(new DateTimeOffsetConverter(), src => src.EffectiveDate)) 
+                 .ForMember(dest => dest.IdentificationExpirationDate, opt => opt.ConvertUsing(new DateTimeOffsetConverter(), src => src.ExpirationDate))
                  .ForMember(dest => dest.IdentifierType, opt => opt.ConvertUsing(new PersonalIdentifierTypeConverter(), src => src.Type))
-                 .ForMember(dest => dest.InformationSource, opt => opt.ConvertUsing(new IssuedByTypeConverter(), src=>src.IssuedBy))
+                 .ForMember(dest => dest.InformationSource, opt => opt.ConvertUsing(new IssuedByTypeConverter(), src => src.IssuedBy))
                  .ForMember(dest => dest.StateCode, opt => opt.MapFrom(src => 0))
                  .ForMember(dest => dest.StatusCode, opt => opt.MapFrom(src => 1));
         }

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/PersonSearch/Models/Person.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/PersonSearch/Models/Person.cs
@@ -7,27 +7,8 @@ using System.Threading.Tasks;
 namespace DynamicsAdapter.Web.PersonSearch.Models
 {
     // TODO: all classes bellow will be coming from SEARCH API CORE LIB
-    public enum PersonalIdentifierType
+    public class PersonalIdentifierConcrete : PersonalIdentifier
     {
-        DriverLicense,
-        SocialInsuranceNumber,
-        PersonalHealthNumber,
-        BirthCertificate,
-        CorrectionsId,
-        NativeStatusCard,
-        Passport,
-        WcbClaim,
-        Other,
-        SecurityKeyword
-    }
-
-    public class PersonalIdentifier
-    {
-        public string SerialNumber { get; set; }
-        public DateTime? EffectiveDate { get; set; }
-        public DateTime? ExpirationDate { get; set; }
-        public PersonalIdentifierType Type { get; set; }
-        public string IssuedBy { get; set; }
     }
 
     public class Person
@@ -35,7 +16,7 @@ namespace DynamicsAdapter.Web.PersonSearch.Models
         public string FirstName { get; set; }
         public string LastName { get; set; }
         public DateTime? DateOfBirth { get; set; }
-        public IEnumerable<PersonalIdentifier> Identifiers { get; set; }
+        public IEnumerable<PersonalIdentifierConcrete> Identifiers { get; set; }
         public IEnumerable<Address> Addresses { get; set; }
     }
 }

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/SearchRequest/SearchRequestJob.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/SearchRequest/SearchRequestJob.cs
@@ -63,7 +63,6 @@ namespace DynamicsAdapter.Web.SearchRequest
                     _logger.LogInformation($"Successfully posted person search id:{result.Id}");
 
                     await MarkInProgress(ssgSearchRequest, cts.Token);
-
                 }
             }
             catch(Exception e) 

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/searchApi.openapi.json
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/searchApi.openapi.json
@@ -90,38 +90,64 @@
         "identifiers": {
           "type": "array",
           "items": {
-            "$ref": "#/definitions/Identifier"
-          },
-          "description": "The list of exsiting identifiers of the subject"
+            "$ref": "#/definitions/PersonalIdentifier"
+          }
         }
       }
     },
-    "Identifier": {
+    "PersonalIdentifier": {
       "type": "object",
-      "description": "Identifier",
+      "x-abstract": true,
+      "required": [
+        "type"
+      ],
       "properties": {
         "serialNumber": {
-          "type": "string",
-          "description": "The identification serial number of this identifier"
+          "type": "string"
         },
         "effectiveDate": {
-          "format": "date-time",
-          "description": "The identification Effective Date"
+          "type": "string",
+          "format": "date-time"
         },
         "expirationDate": {
           "type": "string",
-          "format": "date-time",
-          "description": "The identification expiration date"
+          "format": "date-time"
         },
         "type": {
-          "type": "integer",
-          "description": "The identifier type, such as driver license"
+          "$ref": "#/definitions/PersonalIdentifierType"
         },
         "issuedBy": {
-          "type": "string",
-          "description": "The identifier is issued by who or which organization"
+          "type": "string"
         }
       }
+    },
+    "PersonalIdentifierType": {
+      "type": "string",
+      "description": "",
+      "x-enumNames": [
+        "DriverLicense",
+        "SocialInsuranceNumber",
+        "PersonalHealthNumber",
+        "BirthCertificate",
+        "CorrectionsId",
+        "NativeStatusCard",
+        "Passport",
+        "WcbClaim",
+        "Other",
+        "SecurityKeyword"
+      ],
+      "enum": [
+        "DriverLicense",
+        "SocialInsuranceNumber",
+        "PersonalHealthNumber",
+        "BirthCertificate",
+        "CorrectionsId",
+        "NativeStatusCard",
+        "Passport",
+        "WcbClaim",
+        "Other",
+        "SecurityKeyword"
+      ]
     }
   },
   "tags": [

--- a/app/SearchApi/SearchApi.Web/People/PersonSearchRequest.cs
+++ b/app/SearchApi/SearchApi.Web/People/PersonSearchRequest.cs
@@ -38,10 +38,15 @@ namespace SearchApi.Web.Controllers
 
     public class SearchApiPersonalIdentifier : PersonalIdentifier
     {
+        [Description("The serial number of the identifier.")]
         public string SerialNumber { get; set; }
+        [Description("The effective date of the identifier.")]
         public DateTime? EffectiveDate { get; set; }
+        [Description("The expiration date of the identifier.")]
         public DateTime? ExpirationDate { get; set; }
+        [Description("The type of the identifier.")]
         public PersonalIdentifierType Type { get; set; }
+        [Description("The issuer of the identifier.")]
         public string IssuedBy { get; set; }
     }
 }


### PR DESCRIPTION
# Description

We should not manually modify the generated searchApi.openapi.json. So, dynadapter should use auto-generated searchApi.openapi.json.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Tested locally

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes

## For bcgov contributors:

this PR fixes jira ticket: FAMS-952
