### PR TITLE
Add SeriLog as default logger for search APi

### DIFF
--- a/app/SearchApi/SearchApi.Web.Test/People/PeopleControllerTest.cs
+++ b/app/SearchApi/SearchApi.Web.Test/People/PeopleControllerTest.cs
@@ -41,7 +41,7 @@ namespace SearchApi.Web.Test.People
         public void With_valid_payload_should_return_created()
         {
             var result =
-                (AcceptedResult) this._sut.Search(null, new PersonSearchRequest("firstName", "lastName", null, new List<SearchApiPersonalIdentifier>())).Result;
+                (AcceptedResult) this._sut.Search(null, new PersonSearchRequest("firstName", "lastName", null, new List<SearchApiPersonalIdentifier>(), new List<SearchApiAddress>(), new List<SearchApiPhoneNumber>())).Result;
             Assert.IsInstanceOf<PersonSearchResponse>(result.Value);
             Assert.IsNotNull(((PersonSearchResponse)result.Value).Id);
             _spanMock.Verify(x => x.SetTag("searchRequestId", $"{((PersonSearchResponse)result.Value).Id}"), Times.Once);
@@ -54,7 +54,7 @@ namespace SearchApi.Web.Test.People
             var expectedId = Guid.NewGuid();
 
             var result =
-                (AcceptedResult)this._sut.Search($"{expectedId}", new PersonSearchRequest("firstName", "lastName", null, new List<SearchApiPersonalIdentifier>())).Result;
+                (AcceptedResult)this._sut.Search($"{expectedId}", new PersonSearchRequest("firstName", "lastName", null, new List<SearchApiPersonalIdentifier>(), new List<SearchApiAddress>(), new List<SearchApiPhoneNumber>())).Result;
             Assert.IsInstanceOf<PersonSearchResponse>(result.Value);
             Assert.AreEqual( expectedId, ((PersonSearchResponse)result.Value).Id);
             _spanMock.Verify(x => x.SetTag("searchRequestId", $"{((PersonSearchResponse)result.Value).Id}"), Times.Once);

--- a/app/SearchApi/SearchApi.Web.Test/People/PersonSearchRequestTest.cs
+++ b/app/SearchApi/SearchApi.Web.Test/People/PersonSearchRequestTest.cs
@@ -11,7 +11,7 @@ namespace SearchApi.Web.Test.People
         public void With_args_it_should_create()
         {
 
-            var sut = new PersonSearchRequest("firstName", "lastName", new DateTime(2001, 1, 12), new List<SearchApiPersonalIdentifier>());
+            var sut = new PersonSearchRequest("firstName", "lastName", new DateTime(2001, 1, 12), new List<SearchApiPersonalIdentifier>(), new List<SearchApiAddress>(), new List<SearchApiPhoneNumber>() );
 
             Assert.AreEqual("firstName", sut.FirstName);
             Assert.AreEqual("lastName", sut.LastName);

--- a/app/SearchApi/SearchApi.Web/People/PersonSearchRequest.cs
+++ b/app/SearchApi/SearchApi.Web/People/PersonSearchRequest.cs
@@ -17,24 +17,32 @@ namespace SearchApi.Web.Controllers
     {
 
         [JsonConstructor]
-        public PersonSearchRequest(string firstName, string lastName, DateTime? dateOfBirth, IEnumerable<SearchApiPersonalIdentifier> identifiers)
+        public PersonSearchRequest(
+            string firstName, 
+            string lastName, 
+            DateTime? dateOfBirth, 
+            IEnumerable<SearchApiPersonalIdentifier> identifiers,
+            IEnumerable<SearchApiAddress> addresses,
+            IEnumerable<SearchApiPhoneNumber> phoneNumbers)
         {
             this.FirstName = firstName;
             this.LastName = lastName;
             this.DateOfBirth = dateOfBirth;
             this.Identifiers = identifiers;
+            this.PhoneNumbers = phoneNumbers;
         }
 
-        [Description("The first name of the subject.")]
+        [Description("The first name of the subject")]
         public string FirstName { get; }
-        [Description("The last name of the subject.")]
+        [Description("The last name of the subject")]
         public string LastName { get; }
-        [Description("The date of birth of the subject.")]
+        [Description("The date of birth of the subject")]
         public DateTime? DateOfBirth { get; }
-
+        [Description("A collection of Personal Identifiers")]
         public IEnumerable<PersonalIdentifier> Identifiers { get; set; }
+        [Description("A collection of addresses")]
         public IEnumerable<Address> Addresses { get; set; }
-
+        [Description("A collection of phone numbers")]
         public IEnumerable<PhoneNumber> PhoneNumbers { get; set; }
 
 
@@ -43,15 +51,50 @@ namespace SearchApi.Web.Controllers
 
     public class SearchApiPersonalIdentifier : PersonalIdentifier
     {
-        [Description("The serial number of the identifier.")]
+        [Description("The serial number of the identifier")]
         public string SerialNumber { get; set; }
-        [Description("The effective date of the identifier.")]
+        [Description("The effective date of the identifier")]
         public DateTime? EffectiveDate { get; set; }
-        [Description("The expiration date of the identifier.")]
+        [Description("The expiration date of the identifier")]
         public DateTime? ExpirationDate { get; set; }
-        [Description("The type of the identifier.")]
+        [Description("The type of the identifier")]
         public PersonalIdentifierType Type { get; set; }
-        [Description("The issuer of the identifier.")]
+        [Description("The issuer of the identifier")]
         public string IssuedBy { get; set; }
+    }
+
+
+    public class SearchApiAddress : Address
+    {
+        [Description("The type of address")]
+        public string Type { get; }
+        [Description("The Address Line 1")]
+        public string AddressLine1 { get; }
+        [Description("The Address Line 2")]
+        public string AddressLine2 { get; }
+        [Description("The Address Province or state")]
+        public string Province { get; }
+        [Description("The Address City")]
+        public string City { get; }
+        [Description("The Address Country")]
+        public string Country { get; }
+        [Description("The Address Zip or Postal Code")]
+        public string PostalCode { get; }
+        public string NonCanadianState { get; }
+        public string SuppliedBy { get; }
+    }
+
+
+    public class SearchApiPhoneNumber : PhoneNumber
+    {
+        public string SuppliedBy { get; }
+        [Description("A Date")]
+        public DateTime? Date { get; }
+        [Description("The Date type of the supplied Date")]
+        public string DateType { get; }
+        [Description("The Phone number")]
+        public string PhoneNumber { get; }
+        [Description("The phone number type")]
+        public string PhoneNumberType { get; }
     }
 }

--- a/app/SearchApi/SearchApi.Web/Program.cs
+++ b/app/SearchApi/SearchApi.Web/Program.cs
@@ -6,6 +6,8 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Serilog;
+using Serilog.Formatting.Compact;
 
 namespace SearchApi.Web
 {
@@ -13,11 +15,33 @@ namespace SearchApi.Web
     {
         public static void Main(string[] args)
         {
-            CreateHostBuilder(args).Build().Run();
+
+            var configuration = new ConfigurationBuilder()
+            .AddJsonFile("appsettings.json")
+            .Build();
+
+            Log.Logger = new LoggerConfiguration()
+                .ReadFrom.Configuration(configuration)
+                .CreateLogger();
+
+            try
+            {
+                Log.Information("Starting up");
+                CreateHostBuilder(args).Build().Run();
+            }
+            catch (Exception ex)
+            {
+                Log.Fatal(ex, "Application start-up failed");
+            }
+            finally
+            {
+                Log.CloseAndFlush();
+            }
         }
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
+                .UseSerilog()
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.UseStartup<Startup>();

--- a/app/SearchApi/SearchApi.Web/SearchApi.Web.csproj
+++ b/app/SearchApi/SearchApi.Web/SearchApi.Web.csproj
@@ -25,6 +25,8 @@
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.0.0" />
     <PackageReference Include="NSwag.AspNetCore" Version="13.1.3" />
     <PackageReference Include="OpenTracing.Contrib.NetCore" Version="0.6.2" />
+    <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/app/SearchApi/SearchApi.Web/appsettings.json
+++ b/app/SearchApi/SearchApi.Web/appsettings.json
@@ -1,12 +1,16 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
+  "AllowedHosts": "*",
+  "Serilog": {
+    "Using": [ "Serilog.Sinks.Console" ],
+    "MinimumLevel": "Debug",
+    "WriteTo": [
+      { "Name": "Console" }
+    ],
+    "Enrich": [ "FromLogContext", "WithMachineName", "WithThreadId" ],
+    "Properties": {
+      "Application": "SearchApi"
     }
   },
-  "AllowedHosts": "*",
   "RabbitMq": {
     "Host": "localhost",
     "Port": 5672,
@@ -19,6 +23,6 @@
         "Name": "DynAdapter",
         "Uri": "http://localhost:5000"
       }
-    ] 
-  } 
+    ]
+  }
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change:

- Add [serilog](https://serilog.net/) as the default logger
- Fix the issue with the api

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Locally with VS

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## For bcgov contributors:

this PR fixes jira ticket: **FAMS3-1060*
