### PR TITLE
Pull Packages from Artifactory in build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -332,4 +332,4 @@ ASALocalRun/
 .env
 
 # s2i
-!.s2i/bin
+!.s2i/bin/

--- a/.gitignore
+++ b/.gitignore
@@ -330,3 +330,6 @@ ASALocalRun/
 # MFractors (Xamarin productivity tool) working folder 
 .mfractor/
 .env
+
+# s2i
+!.s2i/bin

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,8 @@
 x64/
 x86/
 bld/
-[Bb]in/
+app/*[Bb]in/
+bin/
 [Oo]bj/
 [Ll]og/
 

--- a/.s2i/bin/assemble.sh
+++ b/.s2i/bin/assemble.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-
+echo "Add certs to right location"
 ln -s /etc/ssl/certs /usr/local/ssl/certs
+ls /usr/local/ssl/certs
 /usr/libexec/s2i/assemble
 rc=$?
 

--- a/.s2i/bin/assemble.sh
+++ b/.s2i/bin/assemble.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-ln -s /usr/local/ssl/certs /etc/ssl/certs
+ln -s /etc/ssl/certs /usr/local/ssl/certs
 /usr/libexec/s2i/assemble
 rc=$?
 

--- a/.s2i/bin/assemble.sh
+++ b/.s2i/bin/assemble.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+ln -s /usr/local/ssl/certs /etc/ssl/certs
+/usr/libexec/s2i/assemble
+rc=$?
+
+exit $rc

--- a/openshift/.pipeline/Jenkinsfile
+++ b/openshift/.pipeline/Jenkinsfile
@@ -17,7 +17,7 @@ def DOMAIN = "pathfinder.gov.bc.ca"
 def SUBDOMAIN = "fams3"
 
 def GIT_URI = "https://github.com/bcgov/fams3.git"
-def GIT_REF = "master"
+def GIT_REF = "feature/private-package"
 
 def PRIVATE_GIT_URI = "git@github.com:bcgov-c/fams3-openshift.git"
 def PRIVATE_GIT_REF = "master"

--- a/openshift/.pipeline/Jenkinsfile
+++ b/openshift/.pipeline/Jenkinsfile
@@ -17,7 +17,7 @@ def DOMAIN = "pathfinder.gov.bc.ca"
 def SUBDOMAIN = "fams3"
 
 def GIT_URI = "https://github.com/bcgov/fams3.git"
-def GIT_REF = "feature/private-package"
+def GIT_REF = "master"
 
 def PRIVATE_GIT_URI = "git@github.com:bcgov-c/fams3-openshift.git"
 def PRIVATE_GIT_REF = "master"

--- a/openshift/docker-images/dotnet-3.0/Dockerfile
+++ b/openshift/docker-images/dotnet-3.0/Dockerfile
@@ -1,0 +1,11 @@
+FROM "__FROM_IMAGE_STREAM_DEFINED_IN_TEMPLATE__"
+
+# Install sonar-scanner
+RUN curl -sLo /tmp/sonar-scanner-cli.zip https://dl.bintray.com/sonarsource/SonarQube/org/sonarsource/scanner/cli/sonar-scanner-cli/3.2.0.1227/sonar-scanner-cli-3.2.0.1227-linux.zip && \
+    mkdir ${APP_ROOT}/sonar-scanner-cli && unzip -q /tmp/sonar-scanner-cli.zip -d ${APP_ROOT}/sonar-scanner-cli && \
+    mv ${APP_ROOT}/sonar-scanner-cli ${APP_ROOT}/_sonar-scanner-cli && mv ${APP_ROOT}/_sonar-scanner-cli/sonar-scanner-3.2.0.1227-linux ${APP_ROOT}/sonar-scanner-cli && \
+    rm -rf ${APP_ROOT}/_sonar-scanner-cli \
+    rm /tmp/sonar-scanner-cli.zip && \
+    chmod -R 755 ${APP_ROOT}/sonar-scanner-cli
+
+# Install private dependencies

--- a/openshift/docker-images/dotnet-3.0/Dockerfile
+++ b/openshift/docker-images/dotnet-3.0/Dockerfile
@@ -9,3 +9,5 @@ RUN curl -sLo /tmp/sonar-scanner-cli.zip https://dl.bintray.com/sonarsource/Sona
     chmod -R 755 ${APP_ROOT}/sonar-scanner-cli
 
 # Install private dependencies
+RUN dotnet nuget sources add -Name artficatory -Source ${NUGET_REPO} 
+RUN dotnet nuget setapikey ${NUGET_CREDENTIALS} -Source artifactory

--- a/openshift/templates/dynamics-adapter.bc.yaml
+++ b/openshift/templates/dynamics-adapter.bc.yaml
@@ -136,10 +136,6 @@ objects:
               value: "${DOTNET_TOOLS}"
             - name: DOTNET_INCREMENTAL
               value: "true"
-            - name: DOTNET_SSL_DIRS
-              value: /etc/ssl/certs
-            - name: SSL_CERT_DIR
-              value: /etc/ssl/certs
       output:
         to:
           kind: ImageStreamTag

--- a/openshift/templates/dynamics-adapter.bc.yaml
+++ b/openshift/templates/dynamics-adapter.bc.yaml
@@ -138,8 +138,8 @@ objects:
               value: "true"
             - name: DOTNET_SSL_DIRS
               value: /etc/ssl/certs
-            - name: SSL_CERT_FILE
-              value: /etc/ssl/certs/ca-certificates.crt
+            - name: SSL_CERT_DIR
+              value: /etc/ssl/certs
       output:
         to:
           kind: ImageStreamTag

--- a/openshift/templates/dynamics-adapter.bc.yaml
+++ b/openshift/templates/dynamics-adapter.bc.yaml
@@ -138,6 +138,8 @@ objects:
               value: "true"
             - name: DOTNET_SSL_DIRS
               value: /etc/ssl/certs
+            - name: SSL_CERT_FILE
+              value: /etc/ssl/certs/ca-certificates.crt
       output:
         to:
           kind: ImageStreamTag

--- a/openshift/templates/dynamics-adapter.bc.yaml
+++ b/openshift/templates/dynamics-adapter.bc.yaml
@@ -136,6 +136,8 @@ objects:
               value: "${DOTNET_TOOLS}"
             - name: DOTNET_INCREMENTAL
               value: "true"
+            - name: DOTNET_SSL_DIRS
+              value: /etc/ssl/certs
       output:
         to:
           kind: ImageStreamTag

--- a/openshift/templates/dynamics-adapter.bc.yaml
+++ b/openshift/templates/dynamics-adapter.bc.yaml
@@ -80,6 +80,7 @@ parameters:
 - name: DOTNET_RESTORE_CONFIGFILE
   displayName: NuGet.Config file
   description: Set this to a Nuget.Config file. Cannot be combined with DOTNET_RESTORE_SOURCES.
+  value: nuget.config
 objects: 
   - kind: ImageStream
     apiVersion: v1
@@ -106,6 +107,9 @@ objects:
           uri: "${SOURCE_REPOSITORY_URL}"
           ref: "${SOURCE_REPOSITORY_REF}"
         contextDir: "${CONTEXT_DIR}"
+        configMaps:
+          - configMap:
+              name: dotnet-artifactory-configuration
       strategy:
         type: Source
         sourceStrategy:

--- a/openshift/templates/dynamics-adapter.bc.yaml
+++ b/openshift/templates/dynamics-adapter.bc.yaml
@@ -80,7 +80,7 @@ parameters:
 - name: DOTNET_RESTORE_CONFIGFILE
   displayName: NuGet.Config file
   description: Set this to a Nuget.Config file. Cannot be combined with DOTNET_RESTORE_SOURCES.
-  value: nuget.config
+  value: /opt/nuget.config
 objects: 
   - kind: ImageStream
     apiVersion: v1
@@ -110,6 +110,7 @@ objects:
         configMaps:
           - configMap:
               name: dotnet-artifactory-configuration
+            destinationDir: /opt
       strategy:
         type: Source
         sourceStrategy:

--- a/openshift/templates/dynamics-adapter.dc.yaml
+++ b/openshift/templates/dynamics-adapter.dc.yaml
@@ -157,19 +157,19 @@ objects:
                     secretKeyRef:
                       name: dynamics-oauth-credentials
                       key: apigateway-basepath
-              livenessProbe:
-                httpGet:
-                  path: "/health"
-                  port: 8080
-                  scheme: HTTP
-                initialDelaySeconds: 40
-                timeoutSeconds: 15
-              readinessProbe:
-                httpGet:
-                  path: "/health"
-                  port: 8080
-                  scheme: HTTP
-                initialDelaySeconds: 10
-                timeoutSeconds: 30
+              # livenessProbe:
+              #   httpGet:
+              #     path: "/health"
+              #     port: 8080
+              #     scheme: HTTP
+              #   initialDelaySeconds: 40
+              #   timeoutSeconds: 15
+              # readinessProbe:
+              #   httpGet:
+              #     path: "/health"
+              #     port: 8080
+              #     scheme: HTTP
+              #   initialDelaySeconds: 10
+              #   timeoutSeconds: 30
 
 

--- a/openshift/templates/icbc-rest-adapter.bc.yaml
+++ b/openshift/templates/icbc-rest-adapter.bc.yaml
@@ -144,6 +144,8 @@ objects:
               value: "true"
             - name: DOTNET_SSL_DIRS
               value: /etc/ssl/certs
+            - name: SSL_CERT_FILE
+              value: /etc/ssl/certs/ca-certificates.crt
       output:
         to:
           kind: ImageStreamTag

--- a/openshift/templates/icbc-rest-adapter.bc.yaml
+++ b/openshift/templates/icbc-rest-adapter.bc.yaml
@@ -142,6 +142,8 @@ objects:
               value: "${DOTNET_TOOLS}"
             - name: DOTNET_INCREMENTAL
               value: "true"
+            - name: DOTNET_SSL_DIRS
+              value: /etc/ssl/certs
       output:
         to:
           kind: ImageStreamTag

--- a/openshift/templates/icbc-rest-adapter.bc.yaml
+++ b/openshift/templates/icbc-rest-adapter.bc.yaml
@@ -114,7 +114,7 @@ objects:
         configMaps:
           - configMap:
               name: dotnet-artifactory-configuration
-              destination: /opt
+            destinationDir: /opt
         sourceSecret: 
           name: "${SOURCE_SECRET}"
       strategy:

--- a/openshift/templates/icbc-rest-adapter.bc.yaml
+++ b/openshift/templates/icbc-rest-adapter.bc.yaml
@@ -84,7 +84,7 @@ parameters:
 - name: DOTNET_RESTORE_CONFIGFILE
   displayName: NuGet.Config file
   description: Set this to a Nuget.Config file. Cannot be combined with DOTNET_RESTORE_SOURCES.
-  value: nuget.config
+  value: /opt/nuget.config
 objects: 
   - kind: ImageStream
     apiVersion: v1
@@ -114,6 +114,7 @@ objects:
         configMaps:
           - configMap:
               name: dotnet-artifactory-configuration
+              destination: /opt
         sourceSecret: 
           name: "${SOURCE_SECRET}"
       strategy:

--- a/openshift/templates/icbc-rest-adapter.bc.yaml
+++ b/openshift/templates/icbc-rest-adapter.bc.yaml
@@ -142,10 +142,6 @@ objects:
               value: "${DOTNET_TOOLS}"
             - name: DOTNET_INCREMENTAL
               value: "true"
-            - name: DOTNET_SSL_DIRS
-              value: /etc/ssl/certs
-            - name: SSL_CERT_DIR
-              value: /etc/ssl/certs
       output:
         to:
           kind: ImageStreamTag

--- a/openshift/templates/icbc-rest-adapter.bc.yaml
+++ b/openshift/templates/icbc-rest-adapter.bc.yaml
@@ -84,6 +84,7 @@ parameters:
 - name: DOTNET_RESTORE_CONFIGFILE
   displayName: NuGet.Config file
   description: Set this to a Nuget.Config file. Cannot be combined with DOTNET_RESTORE_SOURCES.
+  value: nuget.config
 objects: 
   - kind: ImageStream
     apiVersion: v1
@@ -110,6 +111,9 @@ objects:
           uri: "${SOURCE_REPOSITORY_URL}"
           ref: "${SOURCE_REPOSITORY_REF}"
         contextDir: "${CONTEXT_DIR}"
+        configMaps:
+          - configMap:
+              name: dotnet-artifactory-configuration
         sourceSecret: 
           name: "${SOURCE_SECRET}"
       strategy:

--- a/openshift/templates/icbc-rest-adapter.bc.yaml
+++ b/openshift/templates/icbc-rest-adapter.bc.yaml
@@ -144,8 +144,8 @@ objects:
               value: "true"
             - name: DOTNET_SSL_DIRS
               value: /etc/ssl/certs
-            - name: SSL_CERT_FILE
-              value: /etc/ssl/certs/ca-certificates.crt
+            - name: SSL_CERT_DIR
+              value: /etc/ssl/certs
       output:
         to:
           kind: ImageStreamTag

--- a/openshift/templates/sample-adapter.bc.yaml
+++ b/openshift/templates/sample-adapter.bc.yaml
@@ -136,10 +136,6 @@ objects:
               value: "${DOTNET_TOOLS}"
             - name: DOTNET_INCREMENTAL
               value: "true"
-            - name: DOTNET_SSL_DIRS
-              value: /etc/ssl/certs
-            - name: SSL_CERT_DIR
-              value: /etc/ssl/certs
       output:
         to:
           kind: ImageStreamTag

--- a/openshift/templates/sample-adapter.bc.yaml
+++ b/openshift/templates/sample-adapter.bc.yaml
@@ -138,8 +138,8 @@ objects:
               value: "true"
             - name: DOTNET_SSL_DIRS
               value: /etc/ssl/certs
-            - name: SSL_CERT_FILE
-              value: /etc/ssl/certs/ca-certificates.crt
+            - name: SSL_CERT_DIR
+              value: /etc/ssl/certs
       output:
         to:
           kind: ImageStreamTag

--- a/openshift/templates/sample-adapter.bc.yaml
+++ b/openshift/templates/sample-adapter.bc.yaml
@@ -138,6 +138,8 @@ objects:
               value: "true"
             - name: DOTNET_SSL_DIRS
               value: /etc/ssl/certs
+            - name: SSL_CERT_FILE
+              value: /etc/ssl/certs/ca-certificates.crt
       output:
         to:
           kind: ImageStreamTag

--- a/openshift/templates/sample-adapter.bc.yaml
+++ b/openshift/templates/sample-adapter.bc.yaml
@@ -136,6 +136,8 @@ objects:
               value: "${DOTNET_TOOLS}"
             - name: DOTNET_INCREMENTAL
               value: "true"
+            - name: DOTNET_SSL_DIRS
+              value: /etc/ssl/certs
       output:
         to:
           kind: ImageStreamTag

--- a/openshift/templates/sample-adapter.bc.yaml
+++ b/openshift/templates/sample-adapter.bc.yaml
@@ -80,6 +80,7 @@ parameters:
 - name: DOTNET_RESTORE_CONFIGFILE
   displayName: NuGet.Config file
   description: Set this to a Nuget.Config file. Cannot be combined with DOTNET_RESTORE_SOURCES.
+  value: nuget.config
 objects: 
   - kind: ImageStream
     apiVersion: v1
@@ -106,6 +107,9 @@ objects:
           uri: "${SOURCE_REPOSITORY_URL}"
           ref: "${SOURCE_REPOSITORY_REF}"
         contextDir: "${CONTEXT_DIR}"
+        configMaps:
+          - configMap:
+              name: dotnet-artifactory-configuration
       strategy:
         type: Source
         sourceStrategy:

--- a/openshift/templates/sample-adapter.bc.yaml
+++ b/openshift/templates/sample-adapter.bc.yaml
@@ -80,7 +80,7 @@ parameters:
 - name: DOTNET_RESTORE_CONFIGFILE
   displayName: NuGet.Config file
   description: Set this to a Nuget.Config file. Cannot be combined with DOTNET_RESTORE_SOURCES.
-  value: nuget.config
+  value: /opt/nuget.config
 objects: 
   - kind: ImageStream
     apiVersion: v1
@@ -110,6 +110,7 @@ objects:
         configMaps:
           - configMap:
               name: dotnet-artifactory-configuration
+            destinationDir: /opt
       strategy:
         type: Source
         sourceStrategy:

--- a/openshift/templates/search-api.bc.yaml
+++ b/openshift/templates/search-api.bc.yaml
@@ -136,10 +136,6 @@ objects:
               value: "${DOTNET_TOOLS}"
             - name: DOTNET_INCREMENTAL
               value: "true"
-            - name: DOTNET_SSL_DIRS
-              value: /etc/ssl/certs
-            - name: SSL_CERT_DIR
-              value: /etc/ssl/certs
       output:
         to:
           kind: ImageStreamTag

--- a/openshift/templates/search-api.bc.yaml
+++ b/openshift/templates/search-api.bc.yaml
@@ -138,8 +138,8 @@ objects:
               value: "true"
             - name: DOTNET_SSL_DIRS
               value: /etc/ssl/certs
-            - name: SSL_CERT_FILE
-              value: /etc/ssl/certs/ca-certificates.crt
+            - name: SSL_CERT_DIR
+              value: /etc/ssl/certs
       output:
         to:
           kind: ImageStreamTag

--- a/openshift/templates/search-api.bc.yaml
+++ b/openshift/templates/search-api.bc.yaml
@@ -138,6 +138,8 @@ objects:
               value: "true"
             - name: DOTNET_SSL_DIRS
               value: /etc/ssl/certs
+            - name: SSL_CERT_FILE
+              value: /etc/ssl/certs/ca-certificates.crt
       output:
         to:
           kind: ImageStreamTag

--- a/openshift/templates/search-api.bc.yaml
+++ b/openshift/templates/search-api.bc.yaml
@@ -136,6 +136,8 @@ objects:
               value: "${DOTNET_TOOLS}"
             - name: DOTNET_INCREMENTAL
               value: "true"
+            - name: DOTNET_SSL_DIRS
+              value: /etc/ssl/certs
       output:
         to:
           kind: ImageStreamTag

--- a/openshift/templates/search-api.bc.yaml
+++ b/openshift/templates/search-api.bc.yaml
@@ -80,6 +80,7 @@ parameters:
 - name: DOTNET_RESTORE_CONFIGFILE
   displayName: NuGet.Config file
   description: Set this to a Nuget.Config file. Cannot be combined with DOTNET_RESTORE_SOURCES.
+  value: nuget.config
 objects: 
   - kind: ImageStream
     apiVersion: v1
@@ -106,6 +107,9 @@ objects:
           uri: "${SOURCE_REPOSITORY_URL}"
           ref: "${SOURCE_REPOSITORY_REF}"
         contextDir: "${CONTEXT_DIR}"
+        configMaps:
+          - configMap:
+              name: dotnet-artifactory-configuration
       strategy:
         type: Source
         sourceStrategy:

--- a/openshift/templates/search-api.bc.yaml
+++ b/openshift/templates/search-api.bc.yaml
@@ -80,7 +80,7 @@ parameters:
 - name: DOTNET_RESTORE_CONFIGFILE
   displayName: NuGet.Config file
   description: Set this to a Nuget.Config file. Cannot be combined with DOTNET_RESTORE_SOURCES.
-  value: nuget.config
+  value: /opt/nuget.config
 objects: 
   - kind: ImageStream
     apiVersion: v1
@@ -110,6 +110,7 @@ objects:
         configMaps:
           - configMap:
               name: dotnet-artifactory-configuration
+            destinationDir: /opt
       strategy:
         type: Source
         sourceStrategy:


### PR DESCRIPTION
This PR has the changes necessary to pull the private packages from our Artifactory instance. The specific nuget configurations are contained in a ConfigMap on the frjeow-tools namespace.