### PR TITLE
Soft link of certificate locations for s2i assemble

### DIFF
--- a/.s2i/bin/assemble.sh
+++ b/.s2i/bin/assemble.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 echo "Add certs to right location"
+mkdir /usr/local/ssl
 ln -s /etc/ssl/certs /usr/local/ssl/certs
-ls /usr/local/ssl/certs
 /usr/libexec/s2i/assemble
 rc=$?
 


### PR DESCRIPTION
There is an issue with CoreFX on RHEL images where it is looking in the wrong location for certificate bundles, this is attempting to fix that issue.