### PR TITLE
Stability issues and fixes

### DIFF
--- a/openshift/templates/icbc-web-adapter.bc.yaml
+++ b/openshift/templates/icbc-web-adapter.bc.yaml
@@ -145,8 +145,8 @@ objects:
               value: "true"
             - name: DOTNET_SSL_DIRS
               value: /etc/pki/tls/certs
-            - name: DOTNET_SYSTEM_NET_HTTP_USESOCKETSHTTPHANDLER
-              value: "0"
+            # - name: DOTNET_SYSTEM_NET_HTTP_USESOCKETSHTTPHANDLER
+            #   value: "0"
       output:
         to:
           kind: ImageStreamTag


### PR DESCRIPTION
- REVERTING: Changing build to not use default socket library in attempt to fix Artifactory issues.