### PR TITLE
Add fileId to searchApi

### DIFF
--- a/app/SearchApi/BcGov.Fams3.Redis/Model/SearchRequest.cs
+++ b/app/SearchApi/BcGov.Fams3.Redis/Model/SearchRequest.cs
@@ -9,6 +9,7 @@ namespace BcGov.Fams3.Redis.Model
     public class SearchRequest
     {
         public Guid SearchRequestId { get; set; }
+        public String FileId { get; set; }
         public Person Person { get; set; }
 
         public IEnumerable<DataPartner> DataPartners { get; set; }

--- a/app/SearchApi/BcGov.Fams3.Redis/Model/SearchRequest.cs
+++ b/app/SearchApi/BcGov.Fams3.Redis/Model/SearchRequest.cs
@@ -9,7 +9,7 @@ namespace BcGov.Fams3.Redis.Model
     public class SearchRequest
     {
         public Guid SearchRequestId { get; set; }
-        public String FileId { get; set; }
+        public string FileId { get; set; }
         public Person Person { get; set; }
 
         public IEnumerable<DataPartner> DataPartners { get; set; }

--- a/app/SearchApi/BcGov.Fams3.SearchApi.Contracts/PersonSearch/PersonSearchOrdered.cs
+++ b/app/SearchApi/BcGov.Fams3.SearchApi.Contracts/PersonSearch/PersonSearchOrdered.cs
@@ -3,5 +3,6 @@
     public interface PersonSearchOrdered : PersonSearchEvent
     {
         Person.Person Person { get; }
+        string FileId { get; }
     }
 }

--- a/app/SearchApi/SearchAdapter.Sample.Test/SearchRequestConsumerTest.cs
+++ b/app/SearchApi/SearchAdapter.Sample.Test/SearchRequestConsumerTest.cs
@@ -35,6 +35,7 @@ namespace SearchAdapter.Sample.Test
             public Guid SearchRequestId { get; set; }
             public DateTime TimeStamp { get; set; }
             public Person Person { get; set; }
+            public string FileId { get; set; }
         }
         
         [OneTimeSetUp]
@@ -68,7 +69,8 @@ namespace SearchAdapter.Sample.Test
                     FirstName = "firstName",
                     LastName = "lastName",
                     DateOfBirth = new DateTime(2001, 1, 1)
-                }
+                },
+                FileId="FileId"
             });
 
             await _harness.BusControl.Publish<PersonSearchOrdered>(new PersonSearchOrderedTest()
@@ -80,7 +82,8 @@ namespace SearchAdapter.Sample.Test
                     FirstName = "",
                     LastName = "lastName",
                     DateOfBirth = new DateTime(2001, 1, 1)
-                }
+                },
+                FileId = "FileId"
             });
 
         }

--- a/app/SearchApi/SearchApi.Core.Test/Adapters/Middleware/PersonSearchObserverTest.cs
+++ b/app/SearchApi/SearchApi.Core.Test/Adapters/Middleware/PersonSearchObserverTest.cs
@@ -28,6 +28,7 @@ namespace SearchApi.Core.Test.Adapters.Middleware
             public Guid SearchRequestId { get; set; }
             public DateTime TimeStamp { get; set; }
             public Person Person { get; set; }
+            public string FileId { get; set; }
         }
 
 

--- a/app/SearchApi/SearchApi.Web.Test/Messaging/DispatcherTest.cs
+++ b/app/SearchApi/SearchApi.Web.Test/Messaging/DispatcherTest.cs
@@ -78,7 +78,8 @@ namespace SearchApi.Web.Test.Messaging
                         Name = "TEST",
                         Completed = false
                     }
-                }), Guid.NewGuid());
+                },
+                "FileID"), Guid.NewGuid());
 
 
             sendEndpointMock.Verify(x => x.Send<PersonSearchOrdered>(It.IsAny<PersonSearchOrdered>(), It.IsAny<CancellationToken>()),
@@ -107,7 +108,8 @@ namespace SearchApi.Web.Test.Messaging
                     new DataProvider() {Name = "TEST3", Completed= true},
                     new DataProvider() {Name = "TEST4", Completed =false},
                     new DataProvider() {Name = "TEST5", Completed=false}
-                }), Guid.NewGuid());
+                },
+                "FileID"), Guid.NewGuid());
 
 
             sendEndpointMock.Verify(x => x.Send<PersonSearchOrdered>(It.IsAny<PersonSearchOrdered>(), It.IsAny<CancellationToken>()),
@@ -129,7 +131,7 @@ namespace SearchApi.Web.Test.Messaging
                 new List<Name>(),
                 new List<RelatedPerson>(),
                 new List<Employment>(),
-                new List<DataProvider>()), Guid.NewGuid());
+                new List<DataProvider>(), "FileID"), Guid.NewGuid());
 
 
             sendEndpointMock.Verify(x => x.Send<PersonSearchOrdered>(It.IsAny<PersonSearchOrdered>(), It.IsAny<CancellationToken>()),
@@ -151,7 +153,7 @@ namespace SearchApi.Web.Test.Messaging
                 new List<Name>(),
                 new List<RelatedPerson>(),
                 new List<Employment>(),
-                null), Guid.NewGuid());
+                null, "FileID"), Guid.NewGuid());
 
 
             sendEndpointMock.Verify(x => x.Send<PersonSearchOrdered>(It.IsAny<PersonSearchOrdered>(), It.IsAny<CancellationToken>()),
@@ -183,7 +185,7 @@ namespace SearchApi.Web.Test.Messaging
                 new List<Name>(),
                 new List<RelatedPerson>(),
                 new List<Employment>(),
-                null), new Guid()));
+                null, "FileID"), new Guid()));
 
         }
 

--- a/app/SearchApi/SearchApi.Web.Test/People/PeopleControllerTest.cs
+++ b/app/SearchApi/SearchApi.Web.Test/People/PeopleControllerTest.cs
@@ -61,7 +61,7 @@ namespace SearchApi.Web.Test.People
         public void With_valid_payload_should_return_created()
         {
             var result =
-                (AcceptedResult)this._sut.Search(null, new PersonSearchRequest("firstName", "lastName", null, new List<PersonalIdentifier>(), new List<Address>(), new List<Phone>(), new List<Name>(), new List<RelatedPerson>(), new List<Employment>(), new List<DataProvider>())).Result;
+                (AcceptedResult)this._sut.Search(null, new PersonSearchRequest("firstName", "lastName", null, new List<PersonalIdentifier>(), new List<Address>(), new List<Phone>(), new List<Name>(), new List<RelatedPerson>(), new List<Employment>(), new List<DataProvider>(),"fileId")).Result;
 
             Assert.IsInstanceOf<PersonSearchResponse>(result.Value);
             Assert.IsNotNull(((PersonSearchResponse)result.Value).Id);
@@ -74,7 +74,7 @@ namespace SearchApi.Web.Test.People
         public void With_valid_payload_and_id_should_return_created()
         {
             var result =
-                (AcceptedResult)this._sut.Search($"{expectedId}", new PersonSearchRequest("firstName", "lastName", null, new List<PersonalIdentifier>(), new List<Address>(), new List<Phone>(), new List<Name>(), new List<RelatedPerson>(), new List<Employment>(), new List<DataProvider>())).Result;
+                (AcceptedResult)this._sut.Search($"{expectedId}", new PersonSearchRequest("firstName", "lastName", null, new List<PersonalIdentifier>(), new List<Address>(), new List<Phone>(), new List<Name>(), new List<RelatedPerson>(), new List<Employment>(), new List<DataProvider>() , "fileId")).Result;
 
             Assert.IsInstanceOf<PersonSearchResponse>(result.Value);
             Assert.AreEqual(expectedId, ((PersonSearchResponse)result.Value).Id);

--- a/app/SearchApi/SearchApi.Web.Test/People/PersonSearchRequestTest.cs
+++ b/app/SearchApi/SearchApi.Web.Test/People/PersonSearchRequestTest.cs
@@ -14,7 +14,7 @@ namespace SearchApi.Web.Test.People
         {
 
 
-            var sut = new PersonSearchRequest("firstName", "lastName", new DateTime(2001, 1, 12), new List<PersonalIdentifier>(), new List<Address>(), new List<Phone>(), new List<Name>(),  new List<RelatedPerson>(), new List<Employment>(), new List<DataProvider>() );
+            var sut = new PersonSearchRequest("firstName", "lastName", new DateTime(2001, 1, 12), new List<PersonalIdentifier>(), new List<Address>(), new List<Phone>(), new List<Name>(),  new List<RelatedPerson>(), new List<Employment>(), new List<DataProvider>(), "fileId");
 
             Assert.AreEqual("firstName", sut.FirstName);
             Assert.AreEqual("lastName", sut.LastName);

--- a/app/SearchApi/SearchApi.Web/Messaging/Dispatcher.cs
+++ b/app/SearchApi/SearchApi.Web/Messaging/Dispatcher.cs
@@ -41,17 +41,17 @@ namespace SearchApi.Web.Messaging
             if(personSearchRequest == null) throw new ArgumentNullException(nameof(personSearchRequest));
             if(searchRequestId.Equals(default(Guid))) throw new ArgumentNullException(nameof(searchRequestId));
 
-            if (personSearchRequest.dataProviders == null)
+            if (personSearchRequest.DataProviders == null)
             {
                 await Task.CompletedTask;
                 return;
             }
 
-            foreach (var requestDataProvider in personSearchRequest.dataProviders)
+            foreach (var requestDataProvider in personSearchRequest.DataProviders)
             {
                 var endpoint = await getEndpointAddress(requestDataProvider.Name);
 
-                await endpoint.Send<PersonSearchOrdered>(new PeopleController.PersonSearchOrderEvent(searchRequestId)
+                await endpoint.Send<PersonSearchOrdered>(new PeopleController.PersonSearchOrderEvent(searchRequestId, personSearchRequest.FileID)
                 {
                     Person = personSearchRequest
                 });

--- a/app/SearchApi/SearchApi.Web/People/PeopleController.cs
+++ b/app/SearchApi/SearchApi.Web/People/PeopleController.cs
@@ -75,7 +75,8 @@ namespace SearchApi.Web.Controllers
             {
                 Person = personSearchRequest,
                 SearchRequestId = searchRequestId,
-                DataPartners = personSearchRequest.dataProviders.Select(x => new DataPartner { Name = x.Name, Completed = false })
+                FileId = personSearchRequest.FileID,
+                DataPartners = personSearchRequest.DataProviders.Select(x => new DataPartner { Name = x.Name, Completed = false })
             };
 
             _logger.LogInformation($"Save Complete Request [{searchRequestId}] to cache. ");
@@ -93,13 +94,15 @@ namespace SearchApi.Web.Controllers
         public class PersonSearchOrderEvent : PersonSearchOrdered
         {
 
-            public PersonSearchOrderEvent(Guid searchRequestId)
+            public PersonSearchOrderEvent(Guid searchRequestId, String fileID)
             {
                 SearchRequestId = searchRequestId;
                 TimeStamp = DateTime.Now;
+                this.FileId = fileID;
             }
 
             public Guid SearchRequestId { get; }
+            public string FileId { get; set; }
             public DateTime TimeStamp { get; }
             public Person Person { get; set; }
         }

--- a/app/SearchApi/SearchApi.Web/People/PeopleController.cs
+++ b/app/SearchApi/SearchApi.Web/People/PeopleController.cs
@@ -94,7 +94,7 @@ namespace SearchApi.Web.Controllers
         public class PersonSearchOrderEvent : PersonSearchOrdered
         {
 
-            public PersonSearchOrderEvent(Guid searchRequestId, String fileID)
+            public PersonSearchOrderEvent(Guid searchRequestId, string fileID)
             {
                 SearchRequestId = searchRequestId;
                 TimeStamp = DateTime.Now;

--- a/app/SearchApi/SearchApi.Web/People/PersonSearchRequest.cs
+++ b/app/SearchApi/SearchApi.Web/People/PersonSearchRequest.cs
@@ -14,7 +14,8 @@ namespace SearchApi.Web.Controllers
     public class PersonSearchRequest : Person
     {
 
-        public IEnumerable<DataProvider> dataProviders { get; set; }
+        public IEnumerable<DataProvider> DataProviders { get; set; }
+        public string FileID { get; set; }
 
         [JsonConstructor]
         public PersonSearchRequest(
@@ -27,7 +28,8 @@ namespace SearchApi.Web.Controllers
             IEnumerable<Name> names, 
             IEnumerable<RelatedPerson> relatedPersons,
             IEnumerable<Employment> employments,
-            IEnumerable<DataProvider> dataProviders)
+            IEnumerable<DataProvider> dataProviders,
+            string fileID)
         {
             this.FirstName = firstName;
             this.LastName = lastName;
@@ -38,7 +40,8 @@ namespace SearchApi.Web.Controllers
             this.Addresses = addresses;
             this.Employments = employments;         
             this.RelatedPersons = relatedPersons;
-            this.dataProviders = dataProviders;
+            this.DataProviders = dataProviders;
+            this.FileID = fileID;
         }
 
     }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- FAMS-1902([SEARCH API] - Add fileId to the PersonSearchRequest and transfer it to webAdapters.)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Tested locally

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
