### PR TITLE
get matched ssg_identifier from cache.

### DIFF
--- a/app/DynamicsAdapter/DynamicsAdapter.Web/PersonSearch/PersonSearchController.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/PersonSearch/PersonSearchController.cs
@@ -1,6 +1,8 @@
 ﻿using AutoMapper;
 using DynamicsAdapter.Web.PersonSearch.Models;
+using DynamicsAdapter.Web.Register;
 using Fams3Adapter.Dynamics;
+using Fams3Adapter.Dynamics.Identifier;
 using Fams3Adapter.Dynamics.SearchApiEvent;
 using Fams3Adapter.Dynamics.SearchApiRequest;
 using Fams3Adapter.Dynamics.SearchRequest;
@@ -23,14 +25,19 @@ namespace DynamicsAdapter.Web.PersonSearch
         private readonly ISearchResultService _searchResultService;
         private readonly ISearchApiRequestService _searchApiRequestService;
         private readonly IMapper _mapper;
+        private readonly ISearchRequestRegister _register;
 
         public PersonSearchController(ISearchResultService searchResultService,
-            ISearchApiRequestService searchApiRequestService, ILogger<PersonSearchController> logger, IMapper mapper)
+            ISearchApiRequestService searchApiRequestService,
+            ILogger<PersonSearchController> logger, 
+            IMapper mapper,
+            ISearchRequestRegister register)
         {
             _searchResultService = searchResultService;
             _searchApiRequestService = searchApiRequestService;
             _logger = logger;
             _mapper = mapper;
+            _register = register;
         }
 
         //POST: Completed/id
@@ -72,9 +79,10 @@ namespace DynamicsAdapter.Web.PersonSearch
                         //{
                         //    await _searchResultService.ProcessPersonFound(p, personCompletedEvent.ProviderProfile, searchRequest, cts.Token);
                         //});
-                        foreach (Person p in personCompletedEvent.MatchedPersons)
+                        foreach (PersonFound p in personCompletedEvent.MatchedPersons)
                         {
-                            await _searchResultService.ProcessPersonFound(p, personCompletedEvent.ProviderProfile, searchRequest, cts.Token);
+                            SSG_Identifier sourceIdentifer = await _register.GetMatchedSourceIdentifier(p.SourcePersonalIdentifier, id);
+                            await _searchResultService.ProcessPersonFound(p, personCompletedEvent.ProviderProfile, searchRequest, cts.Token, sourceIdentifer);
                         }
                     }                   
 

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/PersonSearch/SearchResultService.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/PersonSearch/SearchResultService.cs
@@ -23,7 +23,12 @@ namespace DynamicsAdapter.Web.PersonSearch
 {
     public interface ISearchResultService
     {
-        Task<bool> ProcessPersonFound(Person person, ProviderProfile providerProfile, SSG_SearchRequest searchRequest, CancellationToken cancellationToken);
+        Task<bool> ProcessPersonFound(
+            Person person, 
+            ProviderProfile providerProfile, 
+            SSG_SearchRequest searchRequest,
+            CancellationToken cancellationToken,
+            SSG_Identifier sourceIdentifier=null);
     }
 
     public class SearchResultService : ISearchResultService
@@ -39,7 +44,7 @@ namespace DynamicsAdapter.Web.PersonSearch
             _mapper = mapper;
         }
 
-        public async Task<bool> ProcessPersonFound(Person person, ProviderProfile providerProfile, SSG_SearchRequest request, CancellationToken concellationToken)
+        public async Task<bool> ProcessPersonFound(Person person, ProviderProfile providerProfile, SSG_SearchRequest request, CancellationToken concellationToken, SSG_Identifier sourceIdentifier= null)
         {
             if (person == null) return true;
 

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/Register/SearchRequestRegister.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/Register/SearchRequestRegister.cs
@@ -1,4 +1,5 @@
 ﻿using BcGov.Fams3.Redis;
+using DynamicsAdapter.Web.Mapping;
 using Fams3Adapter.Dynamics.Identifier;
 using Fams3Adapter.Dynamics.SearchApiRequest;
 using Newtonsoft.Json;
@@ -13,6 +14,7 @@ namespace DynamicsAdapter.Web.Register
         SSG_SearchApiRequest FilterDuplicatedIdentifier(SSG_SearchApiRequest request);
         Task<bool> RegisterSearchApiRequest(SSG_SearchApiRequest request);
         Task<SSG_SearchApiRequest> GetSearchApiRequest(Guid guid);
+        Task<SSG_Identifier> GetMatchedSourceIdentifier(PersonalIdentifier identifer, Guid searchApiRequestId);
     }
 
     public class SearchRequestRegister : ISearchRequestRegister
@@ -48,5 +50,12 @@ namespace DynamicsAdapter.Web.Register
             return JsonConvert.DeserializeObject<SSG_SearchApiRequest>(data);
         }
 
+        public async Task<SSG_Identifier> GetMatchedSourceIdentifier(PersonalIdentifier identifer, Guid searchApiRequestId)
+        {
+            SSG_SearchApiRequest searchApiReqeust = await GetSearchApiRequest(searchApiRequestId);
+            return searchApiReqeust.Identifiers.FirstOrDefault(
+                m => m.Identification == identifer.Value
+                     && m.IdentifierType == IDType.IDTypeDictionary.FirstOrDefault(m => m.Value == identifer.Type).Key);
+        }  
     }
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- FAMS3-2201(dynadapter-get GUID from Redis cache for source Identifier)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation

## How Has This Been Tested?

Tested locally and unit tests

## Checklist:

- [X] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
