### PR TITLE
Feature/dynadapter/sequence number

### DIFF
--- a/app/DynamicsAdapter/DynamicsAdapter.Web.Test/Mapping/MappingProfileTest.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web.Test/Mapping/MappingProfileTest.cs
@@ -92,8 +92,7 @@ namespace DynamicsAdapter.Web.Test.Mapping
             Assert.AreEqual(new DateTimeOffset(new DateTime(2002, 2, 2)), personSearchRequest.DateOfBirth);
             Assert.AreEqual(2, personSearchRequest.Identifiers.Count);
             Assert.AreEqual(2, personSearchRequest.DataProviders.Count);
-            Assert.AreEqual("testFileId", personSearchRequest.FileID);
-            Assert.AreEqual("123456", personSearchRequest.SequenceNumber);
+            Assert.AreEqual("testFileId_123456", personSearchRequest.SearchRequestKey);
         }
 
         [Test]

--- a/app/DynamicsAdapter/DynamicsAdapter.Web.Test/Mapping/MappingProfileTest.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web.Test/Mapping/MappingProfileTest.cs
@@ -83,7 +83,8 @@ namespace DynamicsAdapter.Web.Test.Mapping
                     new SSG_SearchapiRequestDataProvider(){AdaptorName="ICBC"},
                     new SSG_SearchapiRequestDataProvider(){AdaptorName="BC Hydro"}
                 },
-                SearchRequest = new SSG_SearchRequest() { FileId = "testFileId" }
+                SearchRequest = new SSG_SearchRequest() { FileId = "testFileId" },
+                SequenceNumber = "123456"
             };
             PersonSearchRequest personSearchRequest = _mapper.Map<PersonSearchRequest>(sSG_SearchApiRequest);
             Assert.AreEqual("firstName", personSearchRequest.FirstName);
@@ -92,6 +93,7 @@ namespace DynamicsAdapter.Web.Test.Mapping
             Assert.AreEqual(2, personSearchRequest.Identifiers.Count);
             Assert.AreEqual(2, personSearchRequest.DataProviders.Count);
             Assert.AreEqual("testFileId", personSearchRequest.FileID);
+            Assert.AreEqual("123456", personSearchRequest.SequenceNumber);
         }
 
         [Test]

--- a/app/DynamicsAdapter/DynamicsAdapter.Web.Test/PersonSearch/PersonSearchControllerTest.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web.Test/PersonSearch/PersonSearchControllerTest.cs
@@ -216,7 +216,7 @@ namespace DynamicsAdapter.Web.Test.PersonSearch
                .Returns(Task.FromResult<SSG_SearchApiRequest>(new SSG_SearchApiRequest()
                {
                   SearchApiRequestId = _testGuid,
-                   Name = "Random Event"
+                  SequenceNumber="1234567"
                }));
 
             _searchResultServiceMock.Setup(x => x.ProcessPersonFound(It.Is<Person>(x => x.FirstName == "TEST1"),It.IsAny<ProviderProfile>(), It.IsAny<SSG_SearchRequest>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>(), It.IsAny<SSG_Identifier>()))

--- a/app/DynamicsAdapter/DynamicsAdapter.Web.Test/Register/SearchRequestRegisterTest.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web.Test/Register/SearchRequestRegisterTest.cs
@@ -22,6 +22,9 @@ namespace DynamicsAdapter.Web.Test.Register
         private Guid _validSouceIdentifierGuid;
         private Guid _wrongSearchApiRequestGuid;
         private Guid _wrongSourceIdentifierGuid;
+        private string _validFileId;
+        private string _invalidFileId;
+        private string _validSeqNumber;
         private SSG_SearchApiRequest _fakeRequest;
         private PersonalIdentifier _fakeIdentifier;
         private PersonalIdentifier _wrongIdentifier;
@@ -34,6 +37,9 @@ namespace DynamicsAdapter.Web.Test.Register
             _validSouceIdentifierGuid = Guid.NewGuid();
             _wrongSearchApiRequestGuid = Guid.NewGuid();
             _wrongSourceIdentifierGuid = Guid.NewGuid();
+            _validFileId = "123456";
+            _invalidFileId = "222222";
+            _validSeqNumber = "654321";
 
             _fakeRequest = new SSG_SearchApiRequest
             {
@@ -66,10 +72,19 @@ namespace DynamicsAdapter.Web.Test.Register
             _cacheServiceMock.Setup(x => x.Get(It.Is<string>(m => m.ToString() == Keys.REDIS_KEY_PREFIX+_validSearchApiRequestGuid.ToString())))
              .Returns(Task.FromResult(JsonConvert.SerializeObject(_fakeRequest)));
 
+            _cacheServiceMock.Setup(x => x.Get(It.Is<string>(m => m == $"{Keys.REDIS_KEY_PREFIX}{_validFileId}_{_validSeqNumber}")))
+            .Returns(Task.FromResult(JsonConvert.SerializeObject(_fakeRequest)));
+
             _cacheServiceMock.Setup(x => x.Delete(It.Is<string>(m => m.ToString() == Keys.REDIS_KEY_PREFIX + _validSearchApiRequestGuid.ToString())))
             .Returns(Task.FromResult(true));
 
+            _cacheServiceMock.Setup(x => x.Delete(It.Is<string>(m => m.ToString() == $"{Keys.REDIS_KEY_PREFIX}{_validFileId}_{_validSeqNumber}")))
+            .Returns(Task.FromResult(true));
+
             _cacheServiceMock.Setup(x => x.Get(It.Is<string>(m => m.ToString() == Keys.REDIS_KEY_PREFIX + _wrongSearchApiRequestGuid.ToString())))
+             .Returns(Task.FromResult(""));
+
+            _cacheServiceMock.Setup(x => x.Get(It.Is<string>(m => m.ToString() == $"{Keys.REDIS_KEY_PREFIX}{_invalidFileId}_{_validSeqNumber}")))
              .Returns(Task.FromResult(""));
 
             _loggerMock = new Mock<ILogger<SearchRequestRegister>>();
@@ -179,9 +194,23 @@ namespace DynamicsAdapter.Web.Test.Register
         }
 
         [Test]
+        public async Task valid_fileId_seqNumber_get_SearchApiRequest_from_cache_correctly()
+        {
+            SSG_SearchApiRequest result = await _sut.GetSearchApiRequest(_validFileId, _validSeqNumber);
+            Assert.AreEqual("111111", result.SearchRequest.FileId);
+        }
+
+        [Test]
         public async Task wrong_guid_wont_get_searchApiRequest()
         {
             SSG_SearchApiRequest result = await _sut.GetSearchApiRequest(_wrongSearchApiRequestGuid);
+            Assert.AreEqual(null, result);
+        }
+
+        [Test]
+        public async Task wrong_fileId_wont_get_searchApiRequest()
+        {
+            SSG_SearchApiRequest result = await _sut.GetSearchApiRequest(_invalidFileId, _validSeqNumber);
             Assert.AreEqual(null, result);
         }
 
@@ -195,9 +224,25 @@ namespace DynamicsAdapter.Web.Test.Register
         }
 
         [Test]
+        public async Task correct_sourceId_validFileId_will_get_correct_ssgIdentifier()
+        {
+            SSG_Identifier result = await _sut.GetMatchedSourceIdentifier(_fakeIdentifier, _validFileId, _validSeqNumber);
+            Assert.AreEqual(IdentificationType.BirthCertificate.Value, result.IdentifierType);
+            Assert.AreEqual("1234567", result.Identification);
+            Assert.AreEqual(_validSouceIdentifierGuid, result.IdentifierId);
+        }
+
+        [Test]
         public async Task wrong_sourceId_will_get_null_ssgIdentifier()
         {
             SSG_Identifier result = await _sut.GetMatchedSourceIdentifier(_wrongIdentifier, _validSearchApiRequestGuid);
+            Assert.AreEqual(null, result);
+        }
+
+        [Test]
+        public async Task wrong_sourceId_validFileId_will_get_null_ssgIdentifier()
+        {
+            SSG_Identifier result = await _sut.GetMatchedSourceIdentifier(_wrongIdentifier, _validFileId,_validSeqNumber);
             Assert.AreEqual(null, result);
         }
 
@@ -210,9 +255,24 @@ namespace DynamicsAdapter.Web.Test.Register
         }
 
         [Test]
+        public async Task wrong_fileId_will_get_null_ssgIdentifier()
+        {
+            SSG_Identifier result = await _sut.GetMatchedSourceIdentifier(_fakeIdentifier, _invalidFileId, _validSeqNumber);
+            _loggerMock.VerifyLog(LogLevel.Error, "Cannot find the searchApiRequest in Redis Cache.", Times.Once());
+            Assert.AreEqual(null, result);
+        }
+
+        [Test]
         public async Task valid_searchApiRequestId_will_be_removed_successfully()
         {
             bool result = await _sut.RemoveSearchApiRequest(_validSearchApiRequestGuid);
+            Assert.AreEqual(true, result);
+        }
+
+        [Test]
+        public async Task valid_fileId_seqNumber_request_will_be_removed_successfully()
+        {
+            bool result = await _sut.RemoveSearchApiRequest(_validFileId, _validSeqNumber);
             Assert.AreEqual(true, result);
         }
     }

--- a/app/DynamicsAdapter/DynamicsAdapter.Web.Test/SearchRequest/SearchRequestJobTest.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web.Test/SearchRequest/SearchRequestJobTest.cs
@@ -95,7 +95,7 @@ namespace DynamicsAdapter.Web.Test.SearchRequest
                .Returns(Task.FromResult<SSG_SearchApiRequest>(new SSG_SearchApiRequest()
                {
                    SearchApiRequestId = _validSearchRequestId,
-                   Name = "Random Event"
+                   SequenceNumber = "1234567"
                }));
 
             _mapperMock.Setup(x => x.Map<PersonSearchRequest>(It.IsAny<SSG_SearchApiRequest>()))

--- a/app/DynamicsAdapter/DynamicsAdapter.Web.Test/SearchRequest/SearchRequestJobTest.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web.Test/SearchRequest/SearchRequestJobTest.cs
@@ -99,7 +99,7 @@ namespace DynamicsAdapter.Web.Test.SearchRequest
                }));
 
             _mapperMock.Setup(x => x.Map<PersonSearchRequest>(It.IsAny<SSG_SearchApiRequest>()))
-                .Returns(new PersonSearchRequest() { FileID = "fileId" });
+                .Returns(new PersonSearchRequest() { SearchRequestKey = "fileId" });
 
             _sut = new SearchRequestJob(
                 _searchApiClientMock.Object,

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/Mapping/MappingProfile.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/Mapping/MappingProfile.cs
@@ -57,6 +57,7 @@ namespace DynamicsAdapter.Web.Mapping
                  .ForMember(dest => dest.LastName, opt => opt.MapFrom(src => src.PersonSurname))
                  .ForMember(dest => dest.DateOfBirth, opt => opt.MapFrom(src => src.PersonBirthDate))
                  .ForMember(dest => dest.Identifiers, opt => opt.MapFrom(src => src.Identifiers))
+                 .ForMember(dest => dest.SequenceNumber, opt => opt.MapFrom(src => src.SequenceNumber))
                  .ForMember(dest => dest.FileID, opt => opt.MapFrom(src => src.SearchRequest == null ? "0" : src.SearchRequest.FileId))
                  .ForMember(dest => dest.DataProviders, opt => opt.MapFrom(src => src.DataProviders));
 

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/Mapping/MappingProfile.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/Mapping/MappingProfile.cs
@@ -57,8 +57,7 @@ namespace DynamicsAdapter.Web.Mapping
                  .ForMember(dest => dest.LastName, opt => opt.MapFrom(src => src.PersonSurname))
                  .ForMember(dest => dest.DateOfBirth, opt => opt.MapFrom(src => src.PersonBirthDate))
                  .ForMember(dest => dest.Identifiers, opt => opt.MapFrom(src => src.Identifiers))
-                 .ForMember(dest => dest.SequenceNumber, opt => opt.MapFrom(src => src.SequenceNumber))
-                 .ForMember(dest => dest.FileID, opt => opt.MapFrom(src => src.SearchRequest == null ? "0" : src.SearchRequest.FileId))
+                 .ForMember(dest => dest.SearchRequestKey, opt => opt.MapFrom(src => src.SearchRequest == null ? "0": $"{src.SearchRequest.FileId}_{src.SequenceNumber}"))
                  .ForMember(dest => dest.DataProviders, opt => opt.MapFrom(src => src.DataProviders));
 
             CreateMap<PersonSearchAccepted, SSG_SearchApiEvent>()

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/searchApi.openapi.json
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/searchApi.openapi.json
@@ -85,10 +85,7 @@
                 "$ref": "#/definitions/DataProvider"
               }
             },
-            "fileID": {
-              "type": "string"
-            },
-            "sequenceNumber": {
+            "searchRequestKey": {
               "type": "string"
             }
           }

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/searchApi.openapi.json
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/searchApi.openapi.json
@@ -87,6 +87,9 @@
             },
             "fileID": {
               "type": "string"
+            },
+            "sequenceNumber": {
+              "type": "string"
             }
           }
         }

--- a/app/DynamicsAdapter/Fams3Adapter.Dynamics/SearchApiRequest/SSG_SearchApiRequest.cs
+++ b/app/DynamicsAdapter/Fams3Adapter.Dynamics/SearchApiRequest/SSG_SearchApiRequest.cs
@@ -36,7 +36,7 @@ namespace Fams3Adapter.Dynamics.SearchApiRequest
         public int StatusCode { get; set; }
 
         [JsonProperty("ssg_name")]
-        public string Name { get; set; }
+        public string SequenceNumber{ get; set; }
 
        [JsonProperty("ssg_ssg_identifier_ssg_searchapirequest")]
         public SSG_Identifier[] Identifiers { get; set; }

--- a/app/SearchApi/SearchApi.Web.Test/Messaging/DispatcherTest.cs
+++ b/app/SearchApi/SearchApi.Web.Test/Messaging/DispatcherTest.cs
@@ -79,7 +79,7 @@ namespace SearchApi.Web.Test.Messaging
                         Completed = false
                     }
                 },
-                "FileID"), Guid.NewGuid());
+                "FileID","123456"), Guid.NewGuid());
 
 
             sendEndpointMock.Verify(x => x.Send<PersonSearchOrdered>(It.IsAny<PersonSearchOrdered>(), It.IsAny<CancellationToken>()),
@@ -109,7 +109,7 @@ namespace SearchApi.Web.Test.Messaging
                     new DataProvider() {Name = "TEST4", Completed =false},
                     new DataProvider() {Name = "TEST5", Completed=false}
                 },
-                "FileID"), Guid.NewGuid());
+                "FileID", "123456"), Guid.NewGuid());
 
 
             sendEndpointMock.Verify(x => x.Send<PersonSearchOrdered>(It.IsAny<PersonSearchOrdered>(), It.IsAny<CancellationToken>()),
@@ -131,7 +131,7 @@ namespace SearchApi.Web.Test.Messaging
                 new List<Name>(),
                 new List<RelatedPerson>(),
                 new List<Employment>(),
-                new List<DataProvider>(), "FileID"), Guid.NewGuid());
+                new List<DataProvider>(), "FileID", "123456"), Guid.NewGuid());
 
 
             sendEndpointMock.Verify(x => x.Send<PersonSearchOrdered>(It.IsAny<PersonSearchOrdered>(), It.IsAny<CancellationToken>()),
@@ -153,7 +153,7 @@ namespace SearchApi.Web.Test.Messaging
                 new List<Name>(),
                 new List<RelatedPerson>(),
                 new List<Employment>(),
-                null, "FileID"), Guid.NewGuid());
+                null, "FileID", "123456"), Guid.NewGuid());
 
 
             sendEndpointMock.Verify(x => x.Send<PersonSearchOrdered>(It.IsAny<PersonSearchOrdered>(), It.IsAny<CancellationToken>()),
@@ -185,7 +185,7 @@ namespace SearchApi.Web.Test.Messaging
                 new List<Name>(),
                 new List<RelatedPerson>(),
                 new List<Employment>(),
-                null, "FileID"), new Guid()));
+                null, "FileID", "123456"), new Guid()));
 
         }
 

--- a/app/SearchApi/SearchApi.Web.Test/People/PeopleControllerTest.cs
+++ b/app/SearchApi/SearchApi.Web.Test/People/PeopleControllerTest.cs
@@ -61,7 +61,7 @@ namespace SearchApi.Web.Test.People
         public void With_valid_payload_should_return_created()
         {
             var result =
-                (AcceptedResult)this._sut.Search(null, new PersonSearchRequest("firstName", "lastName", null, new List<PersonalIdentifier>(), new List<Address>(), new List<Phone>(), new List<Name>(), new List<RelatedPerson>(), new List<Employment>(), new List<DataProvider>(),"fileId")).Result;
+                (AcceptedResult)this._sut.Search(null, new PersonSearchRequest("firstName", "lastName", null, new List<PersonalIdentifier>(), new List<Address>(), new List<Phone>(), new List<Name>(), new List<RelatedPerson>(), new List<Employment>(), new List<DataProvider>(),"fileId", "123456")).Result;
 
             Assert.IsInstanceOf<PersonSearchResponse>(result.Value);
             Assert.IsNotNull(((PersonSearchResponse)result.Value).Id);
@@ -74,7 +74,7 @@ namespace SearchApi.Web.Test.People
         public void With_valid_payload_and_id_should_return_created()
         {
             var result =
-                (AcceptedResult)this._sut.Search($"{expectedId}", new PersonSearchRequest("firstName", "lastName", null, new List<PersonalIdentifier>(), new List<Address>(), new List<Phone>(), new List<Name>(), new List<RelatedPerson>(), new List<Employment>(), new List<DataProvider>() , "fileId")).Result;
+                (AcceptedResult)this._sut.Search($"{expectedId}", new PersonSearchRequest("firstName", "lastName", null, new List<PersonalIdentifier>(), new List<Address>(), new List<Phone>(), new List<Name>(), new List<RelatedPerson>(), new List<Employment>(), new List<DataProvider>() , "fileId", "123456")).Result;
 
             Assert.IsInstanceOf<PersonSearchResponse>(result.Value);
             Assert.AreEqual(expectedId, ((PersonSearchResponse)result.Value).Id);

--- a/app/SearchApi/SearchApi.Web.Test/People/PersonSearchRequestTest.cs
+++ b/app/SearchApi/SearchApi.Web.Test/People/PersonSearchRequestTest.cs
@@ -14,7 +14,7 @@ namespace SearchApi.Web.Test.People
         {
 
 
-            var sut = new PersonSearchRequest("firstName", "lastName", new DateTime(2001, 1, 12), new List<PersonalIdentifier>(), new List<Address>(), new List<Phone>(), new List<Name>(),  new List<RelatedPerson>(), new List<Employment>(), new List<DataProvider>(), "fileId");
+            var sut = new PersonSearchRequest("firstName", "lastName", new DateTime(2001, 1, 12), new List<PersonalIdentifier>(), new List<Address>(), new List<Phone>(), new List<Name>(),  new List<RelatedPerson>(), new List<Employment>(), new List<DataProvider>(), "fileId", "123456");
 
             Assert.AreEqual("firstName", sut.FirstName);
             Assert.AreEqual("lastName", sut.LastName);

--- a/app/SearchApi/SearchApi.Web/People/PersonSearchRequest.cs
+++ b/app/SearchApi/SearchApi.Web/People/PersonSearchRequest.cs
@@ -17,6 +17,8 @@ namespace SearchApi.Web.Controllers
         public IEnumerable<DataProvider> DataProviders { get; set; }
         public string FileID { get; set; }
 
+        public string SequenceNumber { get; set; }
+
         [JsonConstructor]
         public PersonSearchRequest(
             string firstName,
@@ -29,7 +31,8 @@ namespace SearchApi.Web.Controllers
             IEnumerable<RelatedPerson> relatedPersons,
             IEnumerable<Employment> employments,
             IEnumerable<DataProvider> dataProviders,
-            string fileID)
+            string fileID,
+            string sequenceNumber)
         {
             FirstName = firstName;
             LastName = lastName;
@@ -42,6 +45,7 @@ namespace SearchApi.Web.Controllers
             this.RelatedPersons = relatedPersons;
             this.DataProviders = dataProviders;
             this.FileID = fileID;
+            SequenceNumber = sequenceNumber;
         }
 
     }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- FAMS3-2248(dynadapter-save fileID, seq id and searchApi guid to cache. use fileID and seqID as id in contract.)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Tested locally

## Checklist:

- [X] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
