### PR TITLE
fix  docker compose

### DIFF
--- a/app/DynamicsAdapter/DynamicsAdapter.Web/DynamicsAdapter.Web.csproj
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/DynamicsAdapter.Web.csproj
@@ -21,6 +21,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Peggy.BcGov.Fams3.Redis" Version="1.0.0" />
     <PackageReference Include="Quartz" Version="3.0.7" />
     <PackageReference Include="OpenTracing.Contrib.NetCore" Version="0.6.2" />
     <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
@@ -31,7 +32,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\SearchApi\BcGov.Fams3.Redis\BcGov.Fams3.Redis.csproj" />
     <ProjectReference Include="..\Fams3Adapter.Dynamics\Fams3Adapter.Dynamics.csproj" />
   </ItemGroup>
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,9 @@ services:
       RABBITMQ__PASSWORD: guest
       JAEGER_SERVICE_NAME: search-api
       JAEGER_SAMPLER_TYPE: const
+      REDIS__PASSWORD: ${REDIS__PASSWORD}
+      Redis__Host: ${REDIS__HOST}
+      Redis__Port: 6379
       JAEGER_ENDPOINT: http://jaeger-collector:14268/api/traces
       SearchApi__WebHooks__0__Name: dynadapter
       SearchApi__WebHooks__0__Uri: http://dynadapter/PersonSearch
@@ -141,14 +144,14 @@ services:
   redis:
     container_name: redis
     image: redis
-    hostname: redis
-    command: ["redis-server", "--appendonly", "yes", "--requirepass", "${REDIS_PASSWORD}"]
+    hostname: ${REDIS__HOST}
+    command: ["redis-server", "--appendonly", "yes", "--requirepass", "${REDIS__PASSWORD}"]
     ports:
       - "6379:6379"
     networks:
       - search-api-net
     environment: 
-      - REDIS_PASSWORD="test"
+      - REDIS_PASSWORD="${REDIS__PASSWORD}"
     volumes:
       - data-redis:/data
     restart: always
@@ -164,7 +167,7 @@ services:
     ports:
       - "8081:8081"
     environment:
-      - REDIS_HOSTS=redis
+      - REDIS_HOSTS="${REDIS__HOST}"
 networks:
   search-api-net:
     driver: bridge


### PR DESCRIPTION
# Description

Updated docker compose and use library for redis in dynadapter. This is a temporary fix to ensure docker-compose works for local development.

We need to fix nexus / artefactory repository package