### PR TITLE
Feature/search api : use "fileId_seqNo" as the searchRequestKey

### DIFF
--- a/app/DynamicsAdapter/DynamicsAdapter.Web.Test/Mapping/MappingProfileTest.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web.Test/Mapping/MappingProfileTest.cs
@@ -92,7 +92,12 @@ namespace DynamicsAdapter.Web.Test.Mapping
             Assert.AreEqual(new DateTimeOffset(new DateTime(2002, 2, 2)), personSearchRequest.DateOfBirth);
             Assert.AreEqual(2, personSearchRequest.Identifiers.Count);
             Assert.AreEqual(2, personSearchRequest.DataProviders.Count);
+<<<<<<< feature/dynadapter/sequenceNumber
             Assert.AreEqual("testFileId_123456", personSearchRequest.SearchRequestKey);
+=======
+            Assert.AreEqual("testFileId", personSearchRequest.FileID);
+            Assert.AreEqual("123456", personSearchRequest.SequenceNumber);
+>>>>>>> unit tests
         }
 
         [Test]

--- a/app/DynamicsAdapter/DynamicsAdapter.Web.Test/Mapping/MappingProfileTest.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web.Test/Mapping/MappingProfileTest.cs
@@ -92,12 +92,7 @@ namespace DynamicsAdapter.Web.Test.Mapping
             Assert.AreEqual(new DateTimeOffset(new DateTime(2002, 2, 2)), personSearchRequest.DateOfBirth);
             Assert.AreEqual(2, personSearchRequest.Identifiers.Count);
             Assert.AreEqual(2, personSearchRequest.DataProviders.Count);
-<<<<<<< feature/dynadapter/sequenceNumber
             Assert.AreEqual("testFileId_123456", personSearchRequest.SearchRequestKey);
-=======
-            Assert.AreEqual("testFileId", personSearchRequest.FileID);
-            Assert.AreEqual("123456", personSearchRequest.SequenceNumber);
->>>>>>> unit tests
         }
 
         [Test]

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/searchApi.openapi.json
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/searchApi.openapi.json
@@ -87,9 +87,6 @@
             },
             "searchRequestKey": {
               "type": "string"
-            },
-            "sequenceNumber": {
-              "type": "string"
             }
           }
         }

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/searchApi.openapi.json
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/searchApi.openapi.json
@@ -87,6 +87,9 @@
             },
             "searchRequestKey": {
               "type": "string"
+            },
+            "sequenceNumber": {
+              "type": "string"
             }
           }
         }

--- a/app/SearchApi/BcGov.Fams3.Redis.Test/CacheServiceTest.cs
+++ b/app/SearchApi/BcGov.Fams3.Redis.Test/CacheServiceTest.cs
@@ -25,8 +25,8 @@ namespace BcGov.Fams3.Redis.Test
         [SetUp]
         public void SetUp()
         {
-            _existedRequestKey = "111111-000000";
-            _nonExistedRequestKey = "222222-111113";
+            _existedRequestKey = "111111_000000";
+            _nonExistedRequestKey = "222222_111113";
             
 
             _validSearchRequest = new SearchRequest() { Person = null, SearchRequestId = Guid.NewGuid(), SearchRequestKey=_existedRequestKey };

--- a/app/SearchApi/BcGov.Fams3.Redis.Test/CacheServiceTest.cs
+++ b/app/SearchApi/BcGov.Fams3.Redis.Test/CacheServiceTest.cs
@@ -16,8 +16,8 @@ namespace BcGov.Fams3.Redis.Test
         private Mock<IDistributedCache> _distributedCacheMock;
         private Mock<ILogger<CacheService>> _loggerMock;
         private ICacheService _sut;
-        private Guid _existedReqestGuid;
-        private Guid _nonExistedReqestGuid;
+        private string _existedRequestKey;
+        private string _nonExistedRequestKey;
         private SearchRequest _validSearchRequest;
         private string _validRequestString;
         byte[] bytesSearch = null;
@@ -25,17 +25,17 @@ namespace BcGov.Fams3.Redis.Test
         [SetUp]
         public void SetUp()
         {
-            _existedReqestGuid = Guid.Parse("6AE89FE6-9909-EA11-B813-00505683FBF4");
-            _nonExistedReqestGuid = Guid.Parse("66666666-9909-EA11-B813-00505683FBF4");
+            _existedRequestKey = "111111-000000";
+            _nonExistedRequestKey = "222222-111113";
             
 
-            _validSearchRequest = new SearchRequest() { Person = null, SearchRequestId = _existedReqestGuid };
+            _validSearchRequest = new SearchRequest() { Person = null, SearchRequestId = Guid.NewGuid(), SearchRequestKey=_existedRequestKey };
             _validRequestString = JsonConvert.SerializeObject(_validSearchRequest);
 
             _distributedCacheMock = new Mock<IDistributedCache>();
 
             bytesSearch = Encoding.UTF8.GetBytes(_validRequestString);
-            _distributedCacheMock.Setup(x => x.SetAsync(_existedReqestGuid.ToString(),
+            _distributedCacheMock.Setup(x => x.SetAsync(_existedRequestKey,
                 It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), It.IsAny<CancellationToken>()))
                 .Verifiable();
 
@@ -43,13 +43,13 @@ namespace BcGov.Fams3.Redis.Test
       It.IsAny<byte[]>(), It.IsAny<DistributedCacheEntryOptions>(), It.IsAny<CancellationToken>()))
       .Verifiable();
 
-            _distributedCacheMock.Setup(x => x.GetAsync(_existedReqestGuid.ToString(), It.IsAny<CancellationToken>()))
+            _distributedCacheMock.Setup(x => x.GetAsync(_existedRequestKey, It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(bytesSearch));
 
             _distributedCacheMock.Setup(x => x.GetAsync("key", It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult(Encoding.ASCII.GetBytes("data")));
 
-            _distributedCacheMock.Setup(x => x.RemoveAsync(_existedReqestGuid.ToString(),
+            _distributedCacheMock.Setup(x => x.RemoveAsync(_existedRequestKey,
                 It.IsAny<CancellationToken>()))
                .Verifiable();
 
@@ -57,10 +57,10 @@ namespace BcGov.Fams3.Redis.Test
                 It.IsAny<CancellationToken>()))
                .Verifiable();
 
-            _distributedCacheMock.Setup(x => x.GetAsync(_nonExistedReqestGuid.ToString(), It.IsAny<CancellationToken>()))
+            _distributedCacheMock.Setup(x => x.GetAsync(_nonExistedRequestKey, It.IsAny<CancellationToken>()))
          .Returns(Task.FromResult<byte[]>(null));
 
-            _distributedCacheMock.Setup(x => x.RemoveAsync(_nonExistedReqestGuid.ToString(),
+            _distributedCacheMock.Setup(x => x.RemoveAsync(_nonExistedRequestKey,
             It.IsAny<CancellationToken>()))
            .Verifiable();
 
@@ -72,16 +72,16 @@ namespace BcGov.Fams3.Redis.Test
         }
 
         [Test]
-        public void with_existed_serachRequestId_getRequest_return_SearchRequest()
+        public void with_existed_serachRequestKey_getRequest_return_SearchRequest()
         {
-            SearchRequest sr = _sut.GetRequest(_existedReqestGuid).Result;
-            Assert.AreEqual(_existedReqestGuid, sr.SearchRequestId);
+            SearchRequest sr = _sut.GetRequest(_existedRequestKey).Result;
+            Assert.AreEqual(_existedRequestKey, sr.SearchRequestKey);
         }
 
         [Test]
         public void with_nonexisted_searchRequestId_getRequest_return_null()
         {
-            SearchRequest sr = _sut.GetRequest(_nonExistedReqestGuid).Result;
+            SearchRequest sr = _sut.GetRequest(_nonExistedRequestKey).Result;
             Assert.AreEqual(null, sr);
         }
 
@@ -101,7 +101,7 @@ namespace BcGov.Fams3.Redis.Test
         public void with_correct_searchRequest_saveRequest_successfully()
         {
             _sut.SaveRequest(_validSearchRequest);
-            _distributedCacheMock.Verify(x => x.SetAsync(_existedReqestGuid.ToString(), 
+            _distributedCacheMock.Verify(x => x.SetAsync(_existedRequestKey, 
                 It.IsAny<byte[]>(), 
                 It.IsAny<DistributedCacheEntryOptions>(), 
                 It.IsAny<CancellationToken>()), Times.AtLeastOnce ());
@@ -124,28 +124,28 @@ namespace BcGov.Fams3.Redis.Test
         [Test]
         public void with_existed_searchRequestId_deleteRequest_successfully()
         {
-            _sut.DeleteRequest(_existedReqestGuid);
-            _distributedCacheMock.Verify(x => x.RemoveAsync(_existedReqestGuid.ToString(), new CancellationToken()), Times.Once);
+            _sut.DeleteRequest(_existedRequestKey);
+            _distributedCacheMock.Verify(x => x.RemoveAsync(_existedRequestKey, new CancellationToken()), Times.Once);
         }
 
         [Test]
         public void with_nonexisted_serachRequestId_deleteRequest_successfully()
         {
-            _sut.DeleteRequest(_nonExistedReqestGuid);
-            _distributedCacheMock.Verify(x => x.RemoveAsync(_nonExistedReqestGuid.ToString(), new CancellationToken()), Times.Once);
+            _sut.DeleteRequest(_nonExistedRequestKey);
+            _distributedCacheMock.Verify(x => x.RemoveAsync(_nonExistedRequestKey, new CancellationToken()), Times.Once);
         }
 
         [Test]
         public void when_there_null_deleteRequest_throws_it()
         {
-            Assert.ThrowsAsync<ArgumentNullException>(() => _sut.DeleteRequest(new Guid()));
+            Assert.ThrowsAsync<ArgumentNullException>(() => _sut.DeleteRequest(""));
           
         }
 
         [Test]
         public void when_there_null_GetRequest_throws_it()
         {
-            Assert.ThrowsAsync<ArgumentNullException>(() => _sut.GetRequest(new Guid()));
+            Assert.ThrowsAsync<ArgumentNullException>(() => _sut.GetRequest(""));
         }
 
         [Test]

--- a/app/SearchApi/BcGov.Fams3.Redis/ICacheService.cs
+++ b/app/SearchApi/BcGov.Fams3.Redis/ICacheService.cs
@@ -11,10 +11,10 @@ namespace BcGov.Fams3.Redis
     public interface ICacheService
     {
         Task SaveRequest(SearchRequest searchRequest);
-
         Task SaveRequest(string data, string key);
-        Task<SearchRequest> GetRequest(Guid id);
-        Task DeleteRequest(Guid id);
+        Task<SearchRequest> GetRequest(string searchRequestKey);
+        Task DeleteRequest(string id);
+
         Task Save(string key, dynamic data);
         Task<string> Get(string key);
         Task Delete(string key);
@@ -38,36 +38,34 @@ namespace BcGov.Fams3.Redis
 
 
             if (searchRequest is null) throw new ArgumentNullException("SaveRequest : Search request cannot be null");
-            if (searchRequest.SearchRequestId.Equals(default(Guid))) throw new ArgumentNullException("SaveRequest : Search request id cannot be null");
-            await _distributedCache.SetStringAsync(searchRequest.SearchRequestId.ToString(), JsonConvert.SerializeObject(searchRequest), new CancellationToken());
+            if (string.IsNullOrEmpty(searchRequest.SearchRequestKey)) throw new ArgumentNullException("SaveRequest : Search request key cannot be null");
+            await _distributedCache.SetStringAsync(searchRequest.SearchRequestKey, JsonConvert.SerializeObject(searchRequest), new CancellationToken());
 
 
         }
 
         public async Task SaveRequest(string data, string key)
         {
-
-
             if (string.IsNullOrEmpty(data)) throw new ArgumentNullException("SaveRequest : Data cannot be empty");
             if (string.IsNullOrEmpty(key)) throw new ArgumentNullException("SaveRequest : Key cannot be null");
             await _distributedCache.SetStringAsync(key, data, new CancellationToken());
 
         }
 
-        public async Task DeleteRequest(Guid searchRequestId)
+        public async Task DeleteRequest(string searchRequestKey)
         {
 
-            if (searchRequestId.Equals(default(Guid))) throw new ArgumentNullException("DeleteRequest : Search request cannot be null");
-            await _distributedCache.RemoveAsync(searchRequestId.ToString(), new CancellationToken());
+            if (string.IsNullOrEmpty(searchRequestKey)) throw new ArgumentNullException("DeleteRequest : Search request key cannot be null");
+            await _distributedCache.RemoveAsync(searchRequestKey, new CancellationToken());
 
         }
 
-        public async Task<SearchRequest> GetRequest(Guid searchRequestId)
+        public async Task<SearchRequest> GetRequest(string searchRequestKey)
         {
 
-            if (searchRequestId.Equals(default(Guid))) throw new ArgumentNullException("GetRequest : Search request cannot be null");
+            if (string.IsNullOrEmpty(searchRequestKey)) throw new ArgumentNullException("GetRequest : Search request key cannot be null");
 
-            string searchRequestStr = await _distributedCache.GetStringAsync(searchRequestId.ToString(), new CancellationToken());
+            string searchRequestStr = await _distributedCache.GetStringAsync(searchRequestKey.ToString(), new CancellationToken());
             if (searchRequestStr == null) return null;
             return await Task.FromResult(JsonConvert.DeserializeObject<SearchRequest>(searchRequestStr));
 

--- a/app/SearchApi/BcGov.Fams3.Redis/Model/SearchRequest.cs
+++ b/app/SearchApi/BcGov.Fams3.Redis/Model/SearchRequest.cs
@@ -9,7 +9,7 @@ namespace BcGov.Fams3.Redis.Model
     public class SearchRequest
     {
         public Guid SearchRequestId { get; set; }
-        public string FileId { get; set; }
+        public string SearchRequestKey { get; set; }
         public Person Person { get; set; }
 
         public IEnumerable<DataPartner> DataPartners { get; set; }

--- a/app/SearchApi/BcGov.Fams3.SearchApi.Contracts/BcGov.Fams3.SearchApi.Contracts.csproj
+++ b/app/SearchApi/BcGov.Fams3.SearchApi.Contracts/BcGov.Fams3.SearchApi.Contracts.csproj
@@ -2,15 +2,15 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <Version>1.0.33</Version>
+    <Version>1.0.35</Version>
     <Authors>PathFinder</Authors>
     <Company>BcGov</Company>
     <Description />
-    <PackageVersion>1.0.33</PackageVersion>
+    <PackageVersion>1.0.35</PackageVersion>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <AssemblyVersion>1.0.33.0</AssemblyVersion>
-    <FileVersion>1.0.33.0</FileVersion>
+    <AssemblyVersion>1.0.35.0</AssemblyVersion>
+    <FileVersion>1.0.35.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/app/SearchApi/BcGov.Fams3.SearchApi.Contracts/PersonSearch/PersonSearchEvent.cs
+++ b/app/SearchApi/BcGov.Fams3.SearchApi.Contracts/PersonSearch/PersonSearchEvent.cs
@@ -4,8 +4,14 @@ namespace BcGov.Fams3.SearchApi.Contracts.PersonSearch
 {
     public interface PersonSearchEvent
     {
+        /// <summary>
+        /// This is GUID of SearchApiRequestId
+        /// </summary>
         Guid SearchRequestId { get; }
-        string FileId { get; }
+        /// <summary>
+        /// This is the Key to identify the searchRequest, it is made of FileId_SequenceNumber
+        /// </summary>
+        string SearchRequestKey { get; }
         DateTime TimeStamp { get; }
     }
 }

--- a/app/SearchApi/BcGov.Fams3.SearchApi.Core/Adapters/Middleware/PersonSearchObserver.cs
+++ b/app/SearchApi/BcGov.Fams3.SearchApi.Core/Adapters/Middleware/PersonSearchObserver.cs
@@ -39,7 +39,7 @@ namespace BcGov.Fams3.SearchApi.Core.Adapters.Middleware
         {
             _logger.LogError(exception, "Adapter Failed to execute person search.");
                 await context.Publish<PersonSearchFailed>(new DefaultPersonSearchFailed(context.Message.SearchRequestId,
-                    context.Message.FileId,
+                    context.Message.SearchRequestKey,
                     _providerProfile, exception.Message));
         }
     }

--- a/app/SearchApi/BcGov.Fams3.SearchApi.Core/Adapters/Models/DefaultPersonSearchAccepted.cs
+++ b/app/SearchApi/BcGov.Fams3.SearchApi.Core/Adapters/Models/DefaultPersonSearchAccepted.cs
@@ -5,16 +5,16 @@ namespace BcGov.Fams3.SearchApi.Core.Adapters.Models
 {
     public class DefaultPersonSearchAccepted : PersonSearchAccepted
     {
-        public DefaultPersonSearchAccepted(Guid searchRequestId, ProviderProfile providerProfile, string fileId)
+        public DefaultPersonSearchAccepted(Guid searchRequestId, ProviderProfile providerProfile, string SearchRequestKey)
         {
             TimeStamp = DateTime.Now;
             SearchRequestId = searchRequestId;
             ProviderProfile = providerProfile;
-            FileId = fileId;
+            SearchRequestKey = SearchRequestKey;
         }
 
         public Guid SearchRequestId { get; }
-        public String FileId { get; }
+        public String SearchRequestKey { get; }
         public DateTime TimeStamp { get; }
         public ProviderProfile ProviderProfile { get; }
     }

--- a/app/SearchApi/BcGov.Fams3.SearchApi.Core/Adapters/Models/DefaultPersonSearchFailed.cs
+++ b/app/SearchApi/BcGov.Fams3.SearchApi.Core/Adapters/Models/DefaultPersonSearchFailed.cs
@@ -6,17 +6,17 @@ namespace BcGov.Fams3.SearchApi.Core.Adapters.Models
     public class DefaultPersonSearchFailed : PersonSearchFailed
     {
 
-        public DefaultPersonSearchFailed(Guid searchRequestId, string fileId, ProviderProfile providerProfile, string cause)
+        public DefaultPersonSearchFailed(Guid searchRequestId, string SearchRequestKey, ProviderProfile providerProfile, string cause)
         {
             SearchRequestId = searchRequestId;
             ProviderProfile = providerProfile;
             Cause = cause;
             this.TimeStamp = DateTime.Now;
-            this.FileId = fileId;
+            this.SearchRequestKey = SearchRequestKey;
         }
 
         public Guid SearchRequestId { get; }
-        public string FileId { get;  }
+        public string SearchRequestKey { get;  }
         public DateTime TimeStamp { get; }
         public ProviderProfile ProviderProfile { get; }
         public string Cause { get; }

--- a/app/SearchApi/BcGov.Fams3.SearchApi.Core/BcGov.Fams3.SearchApi.Core.csproj
+++ b/app/SearchApi/BcGov.Fams3.SearchApi.Core/BcGov.Fams3.SearchApi.Core.csproj
@@ -5,8 +5,8 @@
     <Authors>PathFinder</Authors>
     <Company>BcGov</Company>
     <Description>A core Librairy for BCGOV SearchApi Related Products</Description>
-    <Version>1.0.33</Version>
-    <PackageVersion>1.0.33</PackageVersion>
+    <Version>1.0.35</Version>
+    <PackageVersion>1.0.35</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/app/SearchApi/SearchAdapter.Sample.Test/SearchRequestConsumerTest.cs
+++ b/app/SearchApi/SearchAdapter.Sample.Test/SearchRequestConsumerTest.cs
@@ -35,7 +35,7 @@ namespace SearchAdapter.Sample.Test
             public Guid SearchRequestId { get; set; }
             public DateTime TimeStamp { get; set; }
             public Person Person { get; set; }
-            public string FileId { get; set; }
+            public string SearchRequestKey { get; set; }
         }
         
         [OneTimeSetUp]
@@ -70,7 +70,7 @@ namespace SearchAdapter.Sample.Test
                     LastName = "lastName",
                     DateOfBirth = new DateTime(2001, 1, 1)
                 },
-                FileId="FileId"
+                SearchRequestKey="SearchRequestKey"
             });
 
             await _harness.BusControl.Publish<PersonSearchOrdered>(new PersonSearchOrderedTest()
@@ -83,7 +83,7 @@ namespace SearchAdapter.Sample.Test
                     LastName = "lastName",
                     DateOfBirth = new DateTime(2001, 1, 1)
                 },
-                FileId = "FileId"
+                SearchRequestKey = "SearchRequestKey"
             });
 
         }

--- a/app/SearchApi/SearchAdapter.Sample.Test/SearchResultConsumerTest.cs
+++ b/app/SearchApi/SearchAdapter.Sample.Test/SearchResultConsumerTest.cs
@@ -31,7 +31,7 @@ namespace SearchAdapter.Sample.Test
         {
             public Guid SearchRequestId { get; set; }
             public DateTime TimeStamp { get; set; }
-            public string FileId { get; set; }
+            public string SearchRequestKey { get; set; }
 
             public string ReceivedPayload { get; set; }
 
@@ -56,7 +56,7 @@ namespace SearchAdapter.Sample.Test
             {
                 SearchRequestId = validGuid,
                 TimeStamp = DateTime.Now,
-                FileId = "FileId",
+                SearchRequestKey = "SearchRequestKey",
                 ReceivedPayload = "{json string}"
             });
 

--- a/app/SearchApi/SearchAdapter.Sample/SearchRequest/PersonSearchEventSample.cs
+++ b/app/SearchApi/SearchAdapter.Sample/SearchRequest/PersonSearchEventSample.cs
@@ -11,21 +11,21 @@ namespace SearchAdapter.Sample.SearchRequest
 
        
         public Guid SearchRequestId { get; set; }
-        public string FileId { get; set; }
+        public string SearchRequestKey { get; set; }
         public DateTime TimeStamp { get; set; }
         public ProviderProfile ProviderProfile { get; set; }
         public IEnumerable<PersonFound> MatchedPersons { get; set; }
     }
     public static class FakePersonBuilder
     {
-        public static PersonSearchCompleted BuildFakePersonSearchCompleted(Guid searchrequestId, string fileid, string firstname, string lastname, DateTime dob, ProviderProfile _profile)
+        public static PersonSearchCompleted BuildFakePersonSearchCompleted(Guid searchrequestId, string SearchRequestKey, string firstname, string lastname, DateTime dob, ProviderProfile _profile)
         {
 
             return new PersonSearchCompletedSample()
             {
                 ProviderProfile = _profile,
                 SearchRequestId = searchrequestId,
-                FileId = fileid,
+                SearchRequestKey = SearchRequestKey,
                 TimeStamp = DateTime.Now,
                 MatchedPersons = new List<PersonFound>()
                 {
@@ -463,12 +463,12 @@ namespace SearchAdapter.Sample.SearchRequest
 
         private readonly List<DefaultValidationResult> _validationResults = new List<DefaultValidationResult>();
 
-        public PersonSearchRejectedEvent(Guid searchRequestId, string fileId, ProviderProfile providerProfile)
+        public PersonSearchRejectedEvent(Guid searchRequestId, string SearchRequestKey, ProviderProfile providerProfile)
         {
             TimeStamp = DateTime.Now;
             SearchRequestId = searchRequestId;
             ProviderProfile = providerProfile;
-            FileId = fileId;
+            SearchRequestKey = SearchRequestKey;
         }
 
         public void AddValidationResult(DefaultValidationResult validationResult)
@@ -477,7 +477,7 @@ namespace SearchAdapter.Sample.SearchRequest
         }
 
         public Guid SearchRequestId { get; }
-        public string FileId { get; }
+        public string SearchRequestKey { get; }
 
         public DateTime TimeStamp { get; }
         public ProviderProfile ProviderProfile { get; }

--- a/app/SearchApi/SearchAdapter.Sample/SearchRequest/SearchRequestConsumer.cs
+++ b/app/SearchApi/SearchAdapter.Sample/SearchRequest/SearchRequestConsumer.cs
@@ -46,7 +46,7 @@ namespace SearchAdapter.Sample.SearchRequest
                 if (string.Equals(context.Message.Person.FirstName, "exception", StringComparison.InvariantCultureIgnoreCase))
                     throw new Exception("Exception from Sample Adapter, Your name is no exception");
                
-                await context.Publish(FakePersonBuilder.BuildFakePersonSearchCompleted(context.Message.SearchRequestId, context.Message.FileId, context.Message.Person.FirstName, context.Message.Person.LastName, (DateTime)context.Message.Person.DateOfBirth, _profile));
+                await context.Publish(FakePersonBuilder.BuildFakePersonSearchCompleted(context.Message.SearchRequestId, context.Message.SearchRequestKey, context.Message.Person.FirstName, context.Message.Person.LastName, (DateTime)context.Message.Person.DateOfBirth, _profile));
             }
         }
 
@@ -58,13 +58,13 @@ namespace SearchAdapter.Sample.SearchRequest
 
             if (validation.IsValid)
             {
-                await context.Publish<PersonSearchAccepted>(new DefaultPersonSearchAccepted(context.Message.SearchRequestId, _profile, context.Message.FileId));
+                await context.Publish<PersonSearchAccepted>(new DefaultPersonSearchAccepted(context.Message.SearchRequestId, _profile, context.Message.SearchRequestKey));
             }
             else
             {
                 _logger.LogInformation("PersonSearch does not have sufficient information for the adapter to proceed the search.");
 
-                var rejectionEvent = new PersonSearchRejectedEvent(context.Message.SearchRequestId, context.Message.FileId, _profile);
+                var rejectionEvent = new PersonSearchRejectedEvent(context.Message.SearchRequestId, context.Message.SearchRequestKey, _profile);
 
                 validation.Errors.ToList().ForEach(x => rejectionEvent.AddValidationResult(new DefaultValidationResult()
                 {

--- a/app/SearchApi/SearchAdapter.Sample/SearchResult/SearchResultConsumer.cs
+++ b/app/SearchApi/SearchAdapter.Sample/SearchResult/SearchResultConsumer.cs
@@ -40,7 +40,7 @@ namespace SearchAdapter.Sample.SearchResult
 
             _logger.LogWarning("Sample Adapter, do not use in PRODUCTION.");
 
-            await context.Publish(FakePersonBuilder.BuildFakePersonSearchCompleted(context.Message.SearchRequestId, context.Message.FileId, "FirstName", "LastName",DateTime.Now, _profile));
+            await context.Publish(FakePersonBuilder.BuildFakePersonSearchCompleted(context.Message.SearchRequestId, context.Message.SearchRequestKey, "FirstName", "LastName",DateTime.Now, _profile));
         }
      
     }

--- a/app/SearchApi/SearchApi.Core.Test/Adapters/Middleware/PersonSearchObserverTest.cs
+++ b/app/SearchApi/SearchApi.Core.Test/Adapters/Middleware/PersonSearchObserverTest.cs
@@ -28,7 +28,7 @@ namespace SearchApi.Core.Test.Adapters.Middleware
             public Guid SearchRequestId { get; set; }
             public DateTime TimeStamp { get; set; }
             public Person Person { get; set; }
-            public string FileId { get; set; }
+            public string SearchRequestKey { get; set; }
         }
 
 

--- a/app/SearchApi/SearchApi.Core.Test/Fake/FakePersonSearchAccepted.cs
+++ b/app/SearchApi/SearchApi.Core.Test/Fake/FakePersonSearchAccepted.cs
@@ -8,7 +8,7 @@ namespace SearchApi.Core.Test.Fake
       
             public Guid SearchRequestId { get; set; }
 
-            public string FileId { get; set; }
+            public string SearchRequestKey { get; set; }
 
             public DateTime TimeStamp { get; set; }
 

--- a/app/SearchApi/SearchApi.Core.Test/Fake/FakePersonSearchAdapeterEvent.cs
+++ b/app/SearchApi/SearchApi.Core.Test/Fake/FakePersonSearchAdapeterEvent.cs
@@ -6,7 +6,7 @@ namespace SearchApi.Core.Test.Fake
     public class FakePersonSearchAdapterEvent : PersonSearchAdapterEvent
     {
         public Guid SearchRequestId { get; set; }
-        public string FileId { get; set; }
+        public string SearchRequestKey { get; set; }
 
         public DateTime TimeStamp { get; set; }
 

--- a/app/SearchApi/SearchApi.Core.Test/Fake/FakePersonSearchCompleted.cs
+++ b/app/SearchApi/SearchApi.Core.Test/Fake/FakePersonSearchCompleted.cs
@@ -10,7 +10,7 @@ namespace SearchApi.Core.Test.Fake
         public IEnumerable<PersonFound> MatchedPersons { get; set; }
 
         public Guid SearchRequestId { get; set; }
-        public string FileId { get; set; }
+        public string SearchRequestKey { get; set; }
 
         public DateTime TimeStamp { get; set; }
 

--- a/app/SearchApi/SearchApi.Core.Test/Fake/FakePersonSearchFailed.cs
+++ b/app/SearchApi/SearchApi.Core.Test/Fake/FakePersonSearchFailed.cs
@@ -8,7 +8,7 @@ namespace SearchApi.Core.Test.Fake
         public string Cause { get; set; }
 
         public Guid SearchRequestId { get; set; }
-        public string FileId { get; set; }
+        public string SearchRequestKey { get; set; }
 
         public DateTime TimeStamp { get; set; }
 

--- a/app/SearchApi/SearchApi.Core.Test/Fake/FakePersonSearchFinalized.cs
+++ b/app/SearchApi/SearchApi.Core.Test/Fake/FakePersonSearchFinalized.cs
@@ -6,7 +6,7 @@ namespace SearchApi.Core.Test.Fake
     public class FakePersonSearchFinalized : PersonSearchFinalized
     {
         public Guid SearchRequestId { get; set; }
-        public string FileId { get; set; }
+        public string SearchRequestKey { get; set; }
 
         public DateTime TimeStamp { get; set; }
 

--- a/app/SearchApi/SearchApi.Core.Test/Fake/FakePersonSearchRejected.cs
+++ b/app/SearchApi/SearchApi.Core.Test/Fake/FakePersonSearchRejected.cs
@@ -10,7 +10,7 @@ namespace SearchApi.Core.Test.Fake
         public IEnumerable<ValidationResult> Reasons {get;set;}
 
         public Guid SearchRequestId { get; set; }
-        public string FileId { get; set; }
+        public string SearchRequestKey { get; set; }
 
         public DateTime TimeStamp { get; set; }
 

--- a/app/SearchApi/SearchApi.Web.Test/Messaging/DispatcherTest.cs
+++ b/app/SearchApi/SearchApi.Web.Test/Messaging/DispatcherTest.cs
@@ -79,7 +79,7 @@ namespace SearchApi.Web.Test.Messaging
                         Completed = false
                     }
                 },
-                "FileID","123456"), Guid.NewGuid());
+                "SearchRequestKey"), Guid.NewGuid());
 
 
             sendEndpointMock.Verify(x => x.Send<PersonSearchOrdered>(It.IsAny<PersonSearchOrdered>(), It.IsAny<CancellationToken>()),
@@ -109,7 +109,7 @@ namespace SearchApi.Web.Test.Messaging
                     new DataProvider() {Name = "TEST4", Completed =false},
                     new DataProvider() {Name = "TEST5", Completed=false}
                 },
-                "FileID", "123456"), Guid.NewGuid());
+                "SearchRequestKey"), Guid.NewGuid());
 
 
             sendEndpointMock.Verify(x => x.Send<PersonSearchOrdered>(It.IsAny<PersonSearchOrdered>(), It.IsAny<CancellationToken>()),
@@ -131,7 +131,7 @@ namespace SearchApi.Web.Test.Messaging
                 new List<Name>(),
                 new List<RelatedPerson>(),
                 new List<Employment>(),
-                new List<DataProvider>(), "FileID", "123456"), Guid.NewGuid());
+                new List<DataProvider>(), "SearchRequestKey"), Guid.NewGuid());
 
 
             sendEndpointMock.Verify(x => x.Send<PersonSearchOrdered>(It.IsAny<PersonSearchOrdered>(), It.IsAny<CancellationToken>()),
@@ -153,7 +153,7 @@ namespace SearchApi.Web.Test.Messaging
                 new List<Name>(),
                 new List<RelatedPerson>(),
                 new List<Employment>(),
-                null, "FileID", "123456"), Guid.NewGuid());
+                null, "SearchRequestKey"), Guid.NewGuid());
 
 
             sendEndpointMock.Verify(x => x.Send<PersonSearchOrdered>(It.IsAny<PersonSearchOrdered>(), It.IsAny<CancellationToken>()),
@@ -185,7 +185,7 @@ namespace SearchApi.Web.Test.Messaging
                 new List<Name>(),
                 new List<RelatedPerson>(),
                 new List<Employment>(),
-                null, "FileID", "123456"), new Guid()));
+                null, "SearchRequestKey"), new Guid()));
 
         }
 

--- a/app/SearchApi/SearchApi.Web.Test/Notifications/WebHookNotifierSearchStatusTest.cs
+++ b/app/SearchApi/SearchApi.Web.Test/Notifications/WebHookNotifierSearchStatusTest.cs
@@ -99,7 +99,7 @@ namespace SearchApi.Web.Test.Notifications
                 var httpClient = new HttpClient(handlerMock.Object);
                 _sut = new WebHookNotifierSearchEventStatus(httpClient, _searchApiOptionsMock.Object, _loggerMock.Object, _cacheServiceMock.Object);
 
-                await _sut.NotifyEventAsync(fakePersonSearchStatus.SearchRequestId, fakePersonSearchStatus, "Accepted",CancellationToken.None);
+                await _sut.NotifyEventAsync(fakePersonSearchStatus.SearchRequestKey, fakePersonSearchStatus, "Accepted",CancellationToken.None);
 
                 var expectedUri = new Uri($"http://test:1234/Accepted/{fakePersonSearchStatus.SearchRequestId}");
 
@@ -127,7 +127,7 @@ namespace SearchApi.Web.Test.Notifications
 
             _searchApiOptionsMock.Setup(x => x.Value).Returns(new SearchApiOptions().AddWebHook("test", "http://test:1234"));
 
-            _cacheServiceMock.Setup(x => x.GetRequest(It.IsAny<Guid>())).Returns(Task.FromResult(_notAllComplete));
+            _cacheServiceMock.Setup(x => x.GetRequest(It.IsAny<string>())).Returns(Task.FromResult(_notAllComplete));
 
             var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
             handlerMock
@@ -149,7 +149,7 @@ namespace SearchApi.Web.Test.Notifications
             var httpClient = new HttpClient(handlerMock.Object);
             _sut = new WebHookNotifierSearchEventStatus(httpClient, _searchApiOptionsMock.Object, _loggerMock.Object, _cacheServiceMock.Object);
 
-            await _sut.NotifyEventAsync(fakePersonSearchStatus.SearchRequestId, fakePersonSearchStatus, "Finalized", CancellationToken.None);
+            await _sut.NotifyEventAsync(fakePersonSearchStatus.SearchRequestKey, fakePersonSearchStatus, "Finalized", CancellationToken.None);
 
             var expectedUri = new Uri($"http://test:1234/Finalized/{fakePersonSearchStatus.SearchRequestId}");
 
@@ -171,7 +171,7 @@ namespace SearchApi.Web.Test.Notifications
         {
             _searchApiOptionsMock.Setup(x => x.Value).Returns(new SearchApiOptions().AddWebHook("test", "http://test:1234"));
 
-            _cacheServiceMock.Setup(x => x.GetRequest(It.IsAny<Guid>())).Returns( Task.FromResult(_allcompleted));
+            _cacheServiceMock.Setup(x => x.GetRequest(It.IsAny<string>())).Returns( Task.FromResult(_allcompleted));
 
             var handlerMock = new Mock<HttpMessageHandler>(MockBehavior.Strict);
             handlerMock
@@ -193,7 +193,7 @@ namespace SearchApi.Web.Test.Notifications
             var httpClient = new HttpClient(handlerMock.Object);
             _sut = new WebHookNotifierSearchEventStatus(httpClient, _searchApiOptionsMock.Object, _loggerMock.Object, _cacheServiceMock.Object);
 
-            await _sut.NotifyEventAsync(fakePersonSearchStatus.SearchRequestId, fakePersonSearchStatus, "Finalized", CancellationToken.None);
+            await _sut.NotifyEventAsync(fakePersonSearchStatus.SearchRequestKey, fakePersonSearchStatus, "Finalized", CancellationToken.None);
 
             var expectedUri = new Uri($"http://test:1234/Finalized/{fakePersonSearchStatus.SearchRequestId}");
 
@@ -238,7 +238,7 @@ namespace SearchApi.Web.Test.Notifications
                 var httpClient = new HttpClient(handlerMock.Object);
                 _sut = new WebHookNotifierSearchEventStatus(httpClient, _searchApiOptionsMock.Object, _loggerMock.Object, _cacheServiceMock.Object);
 
-                await _sut.NotifyEventAsync(fakePersonSearchStatus.SearchRequestId, fakePersonSearchStatus, "Accepted",CancellationToken.None);
+                await _sut.NotifyEventAsync(fakePersonSearchStatus.SearchRequestKey, fakePersonSearchStatus, "Accepted",CancellationToken.None);
 
                 var expectedUri = new Uri($"http://test:1234/Event/Accepted/{fakePersonSearchStatus.SearchRequestId}");
 
@@ -286,7 +286,7 @@ namespace SearchApi.Web.Test.Notifications
                 var httpClient = new HttpClient(handlerMock.Object);
                 _sut = new WebHookNotifierSearchEventStatus(httpClient, _searchApiOptionsMock.Object, _loggerMock.Object, _cacheServiceMock.Object);
 
-                await _sut.NotifyEventAsync(fakePersonSearchStatus.SearchRequestId, fakePersonSearchStatus, "Accepted", CancellationToken.None);
+                await _sut.NotifyEventAsync(fakePersonSearchStatus.SearchRequestKey, fakePersonSearchStatus, "Accepted", CancellationToken.None);
             //
                 var expectedUri = new Uri($"http://test:1234/Accepted/{fakePersonSearchStatus.SearchRequestId}");
                 var expectedUri2 = new Uri($"http://test:5678/Accepted/{fakePersonSearchStatus.SearchRequestId}");
@@ -345,7 +345,7 @@ namespace SearchApi.Web.Test.Notifications
                 var httpClient = new HttpClient(handlerMock.Object);
                 _sut = new WebHookNotifierSearchEventStatus(httpClient, _searchApiOptionsMock.Object, _loggerMock.Object, _cacheServiceMock.Object);
 
-                await _sut.NotifyEventAsync(fakePersonSearchStatus.SearchRequestId, fakePersonSearchStatus, "Accepted",CancellationToken.None);
+                await _sut.NotifyEventAsync(fakePersonSearchStatus.SearchRequestKey, fakePersonSearchStatus, "Accepted",CancellationToken.None);
 
                 _loggerMock.VerifyLog(LogLevel.Warning, $"The webHook PersonSearch notification uri is not established or is not an absolute Uri for test. Set the WebHook.Uri value on SearchApi.WebHooks settings.", "log warning failed");
 
@@ -378,7 +378,7 @@ namespace SearchApi.Web.Test.Notifications
                 var httpClient = new HttpClient(handlerMock.Object);
                 _sut = new WebHookNotifierSearchEventStatus(httpClient, _searchApiOptionsMock.Object, _loggerMock.Object, _cacheServiceMock.Object);
 
-                await _sut.NotifyEventAsync(fakePersonSearchStatus.SearchRequestId, fakePersonSearchStatus, "Accepted", CancellationToken.None);
+                await _sut.NotifyEventAsync(fakePersonSearchStatus.SearchRequestKey, fakePersonSearchStatus, "Accepted", CancellationToken.None);
                 var expectedUri = new Uri($"http://test:1234/Accepted/{fakePersonSearchStatus.SearchRequestId}");
 
                 handlerMock.Protected().Verify(
@@ -423,7 +423,7 @@ namespace SearchApi.Web.Test.Notifications
                 var httpClient = new HttpClient(handlerMock.Object);
                 _sut = new WebHookNotifierSearchEventStatus(httpClient, _searchApiOptionsMock.Object, _loggerMock.Object, _cacheServiceMock.Object);
 
-                await _sut.NotifyEventAsync(fakePersonSearchStatus.SearchRequestId, fakePersonSearchStatus, "Accepted",CancellationToken.None);
+                await _sut.NotifyEventAsync(fakePersonSearchStatus.SearchRequestKey, fakePersonSearchStatus, "Accepted",CancellationToken.None);
                 var expectedUri = new Uri($"http://test:1234/Accepted/{fakePersonSearchStatus.SearchRequestId}");
 
                 handlerMock.Protected().Verify(
@@ -463,7 +463,7 @@ namespace SearchApi.Web.Test.Notifications
                 var httpClient = new HttpClient(handlerMock.Object);
                 _sut = new WebHookNotifierSearchEventStatus(httpClient, _searchApiOptionsMock.Object, _loggerMock.Object, _cacheServiceMock.Object);
 
-                await _sut.NotifyEventAsync(fakePersonSearchStatus.SearchRequestId, new FakePersonSearchAdapterEvent(), "Accepted",CancellationToken.None);
+                await _sut.NotifyEventAsync(fakePersonSearchStatus.SearchRequestKey, new FakePersonSearchAdapterEvent(), "Accepted",CancellationToken.None);
 
                 _loggerMock.VerifyLog(LogLevel.Error, "The webHook PersonSearch notification failed for status Accepted for test webHook. [unknown error]", "failed log error");
 

--- a/app/SearchApi/SearchApi.Web.Test/Notifications/WebHookNotifierSearchStatusTest.cs
+++ b/app/SearchApi/SearchApi.Web.Test/Notifications/WebHookNotifierSearchStatusTest.cs
@@ -63,7 +63,7 @@ namespace SearchApi.Web.Test.Notifications
                 new DataPartner { Name = "BCHydro", Completed = false }
                 }
                 };
-            _mapper = new Mock<IMapper>();
+                _mapper = new Mock<IMapper>();
                 fakePersonSearchStatus = new FakePersonSearchAccepted()
                 {
                     SearchRequestKey = "SearchRequestKey",
@@ -101,7 +101,7 @@ namespace SearchApi.Web.Test.Notifications
 
                 await _sut.NotifyEventAsync(fakePersonSearchStatus.SearchRequestKey, fakePersonSearchStatus, "Accepted",CancellationToken.None);
 
-                var expectedUri = new Uri($"http://test:1234/Accepted/{fakePersonSearchStatus.SearchRequestId}");
+                var expectedUri = new Uri($"http://test:1234/Accepted/{fakePersonSearchStatus.SearchRequestKey}");
 
                 handlerMock.Protected().Verify(
                     "SendAsync",
@@ -195,7 +195,7 @@ namespace SearchApi.Web.Test.Notifications
 
             await _sut.NotifyEventAsync(fakePersonSearchStatus.SearchRequestKey, fakePersonSearchStatus, "Finalized", CancellationToken.None);
 
-            var expectedUri = new Uri($"http://test:1234/Finalized/{fakePersonSearchStatus.SearchRequestId}");
+            var expectedUri = new Uri($"http://test:1234/Finalized/{fakePersonSearchStatus.SearchRequestKey}");
 
             handlerMock.Protected().Verify(
                 "SendAsync",
@@ -240,7 +240,7 @@ namespace SearchApi.Web.Test.Notifications
 
                 await _sut.NotifyEventAsync(fakePersonSearchStatus.SearchRequestKey, fakePersonSearchStatus, "Accepted",CancellationToken.None);
 
-                var expectedUri = new Uri($"http://test:1234/Event/Accepted/{fakePersonSearchStatus.SearchRequestId}");
+                var expectedUri = new Uri($"http://test:1234/Event/Accepted/{fakePersonSearchStatus.SearchRequestKey}");
 
                 handlerMock.Protected().Verify(
                     "SendAsync",
@@ -288,8 +288,8 @@ namespace SearchApi.Web.Test.Notifications
 
                 await _sut.NotifyEventAsync(fakePersonSearchStatus.SearchRequestKey, fakePersonSearchStatus, "Accepted", CancellationToken.None);
             //
-                var expectedUri = new Uri($"http://test:1234/Accepted/{fakePersonSearchStatus.SearchRequestId}");
-                var expectedUri2 = new Uri($"http://test:5678/Accepted/{fakePersonSearchStatus.SearchRequestId}");
+                var expectedUri = new Uri($"http://test:1234/Accepted/{fakePersonSearchStatus.SearchRequestKey}");
+                var expectedUri2 = new Uri($"http://test:5678/Accepted/{fakePersonSearchStatus.SearchRequestKey}");
 
                 handlerMock.Protected().Verify(
                     "SendAsync",
@@ -379,7 +379,7 @@ namespace SearchApi.Web.Test.Notifications
                 _sut = new WebHookNotifierSearchEventStatus(httpClient, _searchApiOptionsMock.Object, _loggerMock.Object, _cacheServiceMock.Object);
 
                 await _sut.NotifyEventAsync(fakePersonSearchStatus.SearchRequestKey, fakePersonSearchStatus, "Accepted", CancellationToken.None);
-                var expectedUri = new Uri($"http://test:1234/Accepted/{fakePersonSearchStatus.SearchRequestId}");
+                var expectedUri = new Uri($"http://test:1234/Accepted/{fakePersonSearchStatus.SearchRequestKey}");
 
                 handlerMock.Protected().Verify(
                     "SendAsync",
@@ -424,7 +424,7 @@ namespace SearchApi.Web.Test.Notifications
                 _sut = new WebHookNotifierSearchEventStatus(httpClient, _searchApiOptionsMock.Object, _loggerMock.Object, _cacheServiceMock.Object);
 
                 await _sut.NotifyEventAsync(fakePersonSearchStatus.SearchRequestKey, fakePersonSearchStatus, "Accepted",CancellationToken.None);
-                var expectedUri = new Uri($"http://test:1234/Accepted/{fakePersonSearchStatus.SearchRequestId}");
+                var expectedUri = new Uri($"http://test:1234/Accepted/{fakePersonSearchStatus.SearchRequestKey}");
 
                 handlerMock.Protected().Verify(
                     "SendAsync",

--- a/app/SearchApi/SearchApi.Web.Test/Notifications/WebHookNotifierSearchStatusTest.cs
+++ b/app/SearchApi/SearchApi.Web.Test/Notifications/WebHookNotifierSearchStatusTest.cs
@@ -66,7 +66,7 @@ namespace SearchApi.Web.Test.Notifications
             _mapper = new Mock<IMapper>();
                 fakePersonSearchStatus = new FakePersonSearchAccepted()
                 {
-                    FileId = "fileId",
+                    SearchRequestKey = "SearchRequestKey",
                     SearchRequestId = Guid.NewGuid(),
                     TimeStamp = DateTime.Now
                 };

--- a/app/SearchApi/SearchApi.Web.Test/People/PeopleControllerTest.cs
+++ b/app/SearchApi/SearchApi.Web.Test/People/PeopleControllerTest.cs
@@ -61,7 +61,7 @@ namespace SearchApi.Web.Test.People
         public void With_valid_payload_should_return_created()
         {
             var result =
-                (AcceptedResult)this._sut.Search(null, new PersonSearchRequest("firstName", "lastName", null, new List<PersonalIdentifier>(), new List<Address>(), new List<Phone>(), new List<Name>(), new List<RelatedPerson>(), new List<Employment>(), new List<DataProvider>(),"fileId", "123456")).Result;
+                (AcceptedResult)this._sut.Search(null, new PersonSearchRequest("firstName", "lastName", null, new List<PersonalIdentifier>(), new List<Address>(), new List<Phone>(), new List<Name>(), new List<RelatedPerson>(), new List<Employment>(), new List<DataProvider>(),"SearchRequestKey")).Result;
 
             Assert.IsInstanceOf<PersonSearchResponse>(result.Value);
             Assert.IsNotNull(((PersonSearchResponse)result.Value).Id);
@@ -74,7 +74,7 @@ namespace SearchApi.Web.Test.People
         public void With_valid_payload_and_id_should_return_created()
         {
             var result =
-                (AcceptedResult)this._sut.Search($"{expectedId}", new PersonSearchRequest("firstName", "lastName", null, new List<PersonalIdentifier>(), new List<Address>(), new List<Phone>(), new List<Name>(), new List<RelatedPerson>(), new List<Employment>(), new List<DataProvider>() , "fileId", "123456")).Result;
+                (AcceptedResult)this._sut.Search($"{expectedId}", new PersonSearchRequest("firstName", "lastName", null, new List<PersonalIdentifier>(), new List<Address>(), new List<Phone>(), new List<Name>(), new List<RelatedPerson>(), new List<Employment>(), new List<DataProvider>() , "SearchRequestKey")).Result;
 
             Assert.IsInstanceOf<PersonSearchResponse>(result.Value);
             Assert.AreEqual(expectedId, ((PersonSearchResponse)result.Value).Id);

--- a/app/SearchApi/SearchApi.Web.Test/People/PersonSearchRequestTest.cs
+++ b/app/SearchApi/SearchApi.Web.Test/People/PersonSearchRequestTest.cs
@@ -14,7 +14,7 @@ namespace SearchApi.Web.Test.People
         {
 
 
-            var sut = new PersonSearchRequest("firstName", "lastName", new DateTime(2001, 1, 12), new List<PersonalIdentifier>(), new List<Address>(), new List<Phone>(), new List<Name>(),  new List<RelatedPerson>(), new List<Employment>(), new List<DataProvider>(), "fileId", "123456");
+            var sut = new PersonSearchRequest("firstName", "lastName", new DateTime(2001, 1, 12), new List<PersonalIdentifier>(), new List<Address>(), new List<Phone>(), new List<Name>(),  new List<RelatedPerson>(), new List<Employment>(), new List<DataProvider>(), "SearchRequestKey");
 
             Assert.AreEqual("firstName", sut.FirstName);
             Assert.AreEqual("lastName", sut.LastName);

--- a/app/SearchApi/SearchApi.Web.Test/Search/PersonSearchAcceptedConsumerTest.cs
+++ b/app/SearchApi/SearchApi.Web.Test/Search/PersonSearchAcceptedConsumerTest.cs
@@ -31,7 +31,7 @@ namespace SearchApi.Web.Test.Search
             _loggerMock = LoggerUtils.LoggerMock<PersonSearchAcceptedConsumer>();
             _searchApiNotifierMock = new Mock<ISearchApiNotifier<PersonSearchAdapterEvent>>();
             _harness = new InMemoryTestHarness();
-            _requestKey = "111111-222222";
+            _requestKey = "111111_222222";
 
             var fakePersonSearchStatus = new FakePersonSearchAccepted
             {

--- a/app/SearchApi/SearchApi.Web.Test/Search/PersonSearchAcceptedConsumerTest.cs
+++ b/app/SearchApi/SearchApi.Web.Test/Search/PersonSearchAcceptedConsumerTest.cs
@@ -22,7 +22,7 @@ namespace SearchApi.Web.Test.Search
         private Mock<ILogger<PersonSearchAcceptedConsumer>> _loggerMock;
         private Mock<ISearchApiNotifier<PersonSearchAdapterEvent>> _searchApiNotifierMock;
 
-        private Guid _requestId;
+        private string _requestKey;
       
 
         [OneTimeSetUp]
@@ -31,11 +31,11 @@ namespace SearchApi.Web.Test.Search
             _loggerMock = LoggerUtils.LoggerMock<PersonSearchAcceptedConsumer>();
             _searchApiNotifierMock = new Mock<ISearchApiNotifier<PersonSearchAdapterEvent>>();
             _harness = new InMemoryTestHarness();
-            _requestId = Guid.NewGuid();
+            _requestKey = "111111-222222";
 
             var fakePersonSearchStatus = new FakePersonSearchAccepted
             {
-                SearchRequestId = _requestId,
+                SearchRequestKey = _requestKey,
                 TimeStamp = DateTime.Now
             };
 
@@ -58,7 +58,7 @@ namespace SearchApi.Web.Test.Search
         public void Should_send_the_initial_message_to_the_consumer()
         {
             Assert.IsTrue(_harness.Consumed.Select<PersonSearchAccepted>().Any());
-            _searchApiNotifierMock.Verify(x => x.NotifyEventAsync(It.Is<Guid>(x => x == _requestId), It.IsAny<PersonSearchAccepted>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+            _searchApiNotifierMock.Verify(x => x.NotifyEventAsync(It.Is<string>(x => x == _requestKey), It.IsAny<PersonSearchAccepted>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
 

--- a/app/SearchApi/SearchApi.Web.Test/Search/PersonSearchCompletedConsumerTest.cs
+++ b/app/SearchApi/SearchApi.Web.Test/Search/PersonSearchCompletedConsumerTest.cs
@@ -31,7 +31,7 @@ namespace SearchApi.Web.Test.Search
             _loggerMock = LoggerUtils.LoggerMock<PersonSearchCompletedConsumer>();
             _searchApiNotifierMock = new Mock<ISearchApiNotifier<PersonSearchAdapterEvent>>();
             _harness = new InMemoryTestHarness();
-            _requestKey = "111111-999999";
+            _requestKey = "111111_999999";
 
             var fakePersonSearchStatus = new FakePersonSearchCompleted
             {

--- a/app/SearchApi/SearchApi.Web.Test/Search/PersonSearchCompletedConsumerTest.cs
+++ b/app/SearchApi/SearchApi.Web.Test/Search/PersonSearchCompletedConsumerTest.cs
@@ -22,7 +22,7 @@ namespace SearchApi.Web.Test.Search
         private Mock<ILogger<PersonSearchCompletedConsumer>> _loggerMock;
         private Mock<ISearchApiNotifier<PersonSearchAdapterEvent>> _searchApiNotifierMock;
 
-        private Guid _requestId;
+        private string _requestKey;
 
 
         [OneTimeSetUp]
@@ -31,11 +31,11 @@ namespace SearchApi.Web.Test.Search
             _loggerMock = LoggerUtils.LoggerMock<PersonSearchCompletedConsumer>();
             _searchApiNotifierMock = new Mock<ISearchApiNotifier<PersonSearchAdapterEvent>>();
             _harness = new InMemoryTestHarness();
-            _requestId = Guid.NewGuid();
+            _requestKey = "111111-999999";
 
             var fakePersonSearchStatus = new FakePersonSearchCompleted
             {
-                SearchRequestId = _requestId,
+                SearchRequestKey = _requestKey,
                 TimeStamp = DateTime.Now
             };
 
@@ -58,7 +58,7 @@ namespace SearchApi.Web.Test.Search
         public void Should_send_the_initial_message_to_the_consumer()
         {
             Assert.IsTrue(_harness.Consumed.Select<PersonSearchCompleted>().Any());
-            _searchApiNotifierMock.Verify(x => x.NotifyEventAsync(It.Is<Guid>(x => x == _requestId), It.IsAny<PersonSearchCompleted>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+            _searchApiNotifierMock.Verify(x => x.NotifyEventAsync(It.Is<string>(x => x == _requestKey), It.IsAny<PersonSearchCompleted>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
         }
     }
 }

--- a/app/SearchApi/SearchApi.Web.Test/Search/PersonSearchFailedConsumerTest.cs
+++ b/app/SearchApi/SearchApi.Web.Test/Search/PersonSearchFailedConsumerTest.cs
@@ -31,7 +31,7 @@ namespace SearchApi.Web.Test.Search
             _loggerMock = LoggerUtils.LoggerMock<PersonSearchFailedConsumer>();
             _searchApiNotifierMock = new Mock<ISearchApiNotifier<PersonSearchAdapterEvent>>();
             _harness = new InMemoryTestHarness();
-            _requestKey = "111111-000000";
+            _requestKey = "111111_000000";
 
             var fakePersonSearchStatus = new FakePersonSearchFailed
             {

--- a/app/SearchApi/SearchApi.Web.Test/Search/PersonSearchFailedConsumerTest.cs
+++ b/app/SearchApi/SearchApi.Web.Test/Search/PersonSearchFailedConsumerTest.cs
@@ -22,7 +22,7 @@ namespace SearchApi.Web.Test.Search
         private Mock<ILogger<PersonSearchFailedConsumer>> _loggerMock;
         private Mock<ISearchApiNotifier<PersonSearchAdapterEvent>> _searchApiNotifierMock;
 
-        private Guid _requestId;
+        private string _requestKey;
       
 
         [OneTimeSetUp]
@@ -31,11 +31,11 @@ namespace SearchApi.Web.Test.Search
             _loggerMock = LoggerUtils.LoggerMock<PersonSearchFailedConsumer>();
             _searchApiNotifierMock = new Mock<ISearchApiNotifier<PersonSearchAdapterEvent>>();
             _harness = new InMemoryTestHarness();
-            _requestId = Guid.NewGuid();
+            _requestKey = "111111-000000";
 
             var fakePersonSearchStatus = new FakePersonSearchFailed
             {
-                SearchRequestId = _requestId,
+                SearchRequestKey = _requestKey,
                 TimeStamp = DateTime.Now
             };
 
@@ -58,7 +58,7 @@ namespace SearchApi.Web.Test.Search
         public void Should_send_the_initial_message_to_the_consumer()
         {
             Assert.IsTrue(_harness.Consumed.Select<PersonSearchFailed>().Any());
-            _searchApiNotifierMock.Verify(x => x.NotifyEventAsync(It.Is<Guid>(x => x == _requestId), It.IsAny<PersonSearchFailed>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+            _searchApiNotifierMock.Verify(x => x.NotifyEventAsync(It.Is<string>(x => x == _requestKey), It.IsAny<PersonSearchFailed>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
 

--- a/app/SearchApi/SearchApi.Web.Test/Search/PersonSearchRejectedConsumerTest.cs
+++ b/app/SearchApi/SearchApi.Web.Test/Search/PersonSearchRejectedConsumerTest.cs
@@ -22,7 +22,7 @@ namespace SearchApi.Web.Test.Search
         private Mock<ILogger<PersonSearchRejectedConsumer>> _loggerMock;
         private Mock<ISearchApiNotifier<PersonSearchAdapterEvent>> _searchApiNotifierMock;
 
-        private Guid _requestId;
+        private string _requestKey;
 
 
         [OneTimeSetUp]
@@ -31,11 +31,11 @@ namespace SearchApi.Web.Test.Search
             _loggerMock = LoggerUtils.LoggerMock<PersonSearchRejectedConsumer>();
             _searchApiNotifierMock = new Mock<ISearchApiNotifier<PersonSearchAdapterEvent>>();
             _harness = new InMemoryTestHarness();
-            _requestId = Guid.NewGuid();
+            _requestKey = "111111-000000";
 
             var fakePersonSearchStatus = new FakePersonSearchRejected
             {
-                SearchRequestId = _requestId,
+                SearchRequestKey = _requestKey,
                 TimeStamp = DateTime.Now
             };
 
@@ -58,7 +58,7 @@ namespace SearchApi.Web.Test.Search
         public void Should_send_the_initial_message_to_the_consumer()
         {
             Assert.IsTrue(_harness.Consumed.Select<PersonSearchRejected>().Any());
-            _searchApiNotifierMock.Verify(x => x.NotifyEventAsync(It.Is<Guid>(x => x == _requestId), It.IsAny<PersonSearchRejected>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+            _searchApiNotifierMock.Verify(x => x.NotifyEventAsync(It.Is<string>(x => x == _requestKey), It.IsAny<PersonSearchRejected>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
         }
     }
 }

--- a/app/SearchApi/SearchApi.Web.Test/Search/PersonSearchRejectedConsumerTest.cs
+++ b/app/SearchApi/SearchApi.Web.Test/Search/PersonSearchRejectedConsumerTest.cs
@@ -31,7 +31,7 @@ namespace SearchApi.Web.Test.Search
             _loggerMock = LoggerUtils.LoggerMock<PersonSearchRejectedConsumer>();
             _searchApiNotifierMock = new Mock<ISearchApiNotifier<PersonSearchAdapterEvent>>();
             _harness = new InMemoryTestHarness();
-            _requestKey = "111111-000000";
+            _requestKey = "111111_000000";
 
             var fakePersonSearchStatus = new FakePersonSearchRejected
             {

--- a/app/SearchApi/SearchApi.Web/Messaging/Dispatcher.cs
+++ b/app/SearchApi/SearchApi.Web/Messaging/Dispatcher.cs
@@ -51,7 +51,7 @@ namespace SearchApi.Web.Messaging
             {
                 var endpoint = await getEndpointAddress(requestDataProvider.Name);
 
-                await endpoint.Send<PersonSearchOrdered>(new PeopleController.PersonSearchOrderEvent(searchRequestId, personSearchRequest.FileID)
+                await endpoint.Send<PersonSearchOrdered>(new PeopleController.PersonSearchOrderEvent(searchRequestId, personSearchRequest.SearchRequestKey)
                 {
                     Person = personSearchRequest
                 });

--- a/app/SearchApi/SearchApi.Web/Notifications/ISearchApiNotifier.cs
+++ b/app/SearchApi/SearchApi.Web/Notifications/ISearchApiNotifier.cs
@@ -8,7 +8,7 @@ namespace SearchApi.Web.Notifications
     public interface ISearchApiNotifier<T>
     {
 
-        Task NotifyEventAsync(Guid searchRequestId, T notificationStatus,string eventName, CancellationToken cancellationToken);
+        Task NotifyEventAsync(string searchRequestKey, T notificationStatus,string eventName, CancellationToken cancellationToken);
 
     }
 

--- a/app/SearchApi/SearchApi.Web/Notifications/PersonSearchFinalizedEvent.cs
+++ b/app/SearchApi/SearchApi.Web/Notifications/PersonSearchFinalizedEvent.cs
@@ -12,7 +12,7 @@ namespace SearchApi.Web.Notifications
 
         public Guid SearchRequestId { get; set; }
 
-        public string FileId { get; set; }
+        public string SearchRequestKey { get; set; }
 
         public DateTime TimeStamp { get; set; }
 

--- a/app/SearchApi/SearchApi.Web/Notifications/URLHelper.cs
+++ b/app/SearchApi/SearchApi.Web/Notifications/URLHelper.cs
@@ -6,7 +6,7 @@ namespace SearchApi.Web.Notifications
 
     public static class URLHelper
     {
-        public static bool TryCreateUri(string baseUrl,  string path, string searchRequestId, out Uri uri)
+        public static bool TryCreateUri(string baseUrl,  string path, string searchRequestKey, out Uri uri)
         {
             uri = null;
             if (!Uri.TryCreate(baseUrl, UriKind.Absolute, out var baseUri))
@@ -14,7 +14,7 @@ namespace SearchApi.Web.Notifications
                 return false;
             }
 
-            return Uri.TryCreate(baseUri, Path.Combine(baseUri.LocalPath, path,searchRequestId), out uri);
+            return Uri.TryCreate(baseUri, Path.Combine(baseUri.LocalPath, path,searchRequestKey), out uri);
         }
     }
 }

--- a/app/SearchApi/SearchApi.Web/Notifications/WebHookNotifierSearchEventStatus.cs
+++ b/app/SearchApi/SearchApi.Web/Notifications/WebHookNotifierSearchEventStatus.cs
@@ -60,7 +60,7 @@ namespace SearchApi.Web.Notifications
                         if (eventName == EventName.Finalized) {
                             PersonSearchEvent finalizedSearch = new PersonSearchFinalizedEvent()
                             {
-                                FileId=eventStatus.FileId,
+                                SearchRequestKey=eventStatus.SearchRequestKey,
                                 Message = "Search Request Finalized",
                                 SearchRequestId= eventStatus.SearchRequestId,
                                 TimeStamp=DateTime.Now

--- a/app/SearchApi/SearchApi.Web/People/PeopleController.cs
+++ b/app/SearchApi/SearchApi.Web/People/PeopleController.cs
@@ -62,7 +62,7 @@ namespace SearchApi.Web.Controllers
         [OpenApiTag("People API")]
         public async Task<IActionResult> Search([FromHeader(Name = "X-RequestId")] string id, [FromBody]PersonSearchRequest personSearchRequest)
         {
-            using (LogContext.PushProperty("FileId", personSearchRequest?.FileID))
+            using (LogContext.PushProperty("SearchRequestKey", personSearchRequest?.SearchRequestKey))
             {
                 if (id == null || !Guid.TryParse(id, out var searchRequestId))
                 {
@@ -77,7 +77,7 @@ namespace SearchApi.Web.Controllers
                 {
                     Person = personSearchRequest,
                     SearchRequestId = searchRequestId,
-                    FileId = personSearchRequest.FileID,
+                    SearchRequestKey = personSearchRequest.SearchRequestKey,
                     DataPartners = personSearchRequest.DataProviders.Select(x => new DataPartner { Name = x.Name, Completed = false })
                 };
 
@@ -97,15 +97,15 @@ namespace SearchApi.Web.Controllers
         public class PersonSearchOrderEvent : PersonSearchOrdered
         {
 
-            public PersonSearchOrderEvent(Guid searchRequestId, string fileID)
+            public PersonSearchOrderEvent(Guid searchRequestId, string SearchRequestKey)
             {
                 SearchRequestId = searchRequestId;
                 TimeStamp = DateTime.Now;
-                this.FileId = fileID;
+                this.SearchRequestKey = SearchRequestKey;
             }
 
             public Guid SearchRequestId { get; }
-            public string FileId { get; set; }
+            public string SearchRequestKey { get; set; }
             public DateTime TimeStamp { get; }
             public Person Person { get; set; }
         }

--- a/app/SearchApi/SearchApi.Web/People/PersonSearchRequest.cs
+++ b/app/SearchApi/SearchApi.Web/People/PersonSearchRequest.cs
@@ -15,9 +15,10 @@ namespace SearchApi.Web.Controllers
     {
 
         public IEnumerable<DataProvider> DataProviders { get; set; }
-        public string FileID { get; set; }
-
-        public string SequenceNumber { get; set; }
+        /// <summary>
+        /// This is the key to identify this search request, it is composed of fileId_SequenceNumber
+        /// </summary>
+        public string SearchRequestKey { get; set; }
 
         [JsonConstructor]
         public PersonSearchRequest(
@@ -31,8 +32,7 @@ namespace SearchApi.Web.Controllers
             IEnumerable<RelatedPerson> relatedPersons,
             IEnumerable<Employment> employments,
             IEnumerable<DataProvider> dataProviders,
-            string fileID,
-            string sequenceNumber)
+            string searchRequestKey)
         {
             FirstName = firstName;
             LastName = lastName;
@@ -44,8 +44,7 @@ namespace SearchApi.Web.Controllers
             this.Employments = employments;         
             this.RelatedPersons = relatedPersons;
             this.DataProviders = dataProviders;
-            this.FileID = fileID;
-            SequenceNumber = sequenceNumber;
+            this.SearchRequestKey = searchRequestKey;
         }
 
     }

--- a/app/SearchApi/SearchApi.Web/Program.cs
+++ b/app/SearchApi/SearchApi.Web/Program.cs
@@ -44,7 +44,7 @@ namespace SearchApi.Web
                 {
                     loggerConfiguration
                         .ReadFrom.Configuration(hostingContext.Configuration)
-                        .Enrich.WithPropertyFileId("FileId")
+                        .Enrich.WithPropertySearchRequestKey("SearchRequestKey")
                         .Enrich.FromLogContext();
 
                     string splunkCollectorUrl = hostingContext.Configuration["SPLUNK_COLLECTOR_URL"];
@@ -79,17 +79,17 @@ namespace SearchApi.Web
 
     public static class EnrichersExtensions
     {
-        public static LoggerConfiguration WithPropertyFileId(this LoggerEnrichmentConfiguration enrichmentConfiguration, string propertyName)
+        public static LoggerConfiguration WithPropertySearchRequestKey(this LoggerEnrichmentConfiguration enrichmentConfiguration, string propertyName)
         {
-            return enrichmentConfiguration.With(new FileIdEnricher(propertyName));
+            return enrichmentConfiguration.With(new SearchRequestKeyEnricher(propertyName));
         }
     }
 
-    public class FileIdEnricher : ILogEventEnricher
+    public class SearchRequestKeyEnricher : ILogEventEnricher
     {
         private readonly string innerPropertyName;
 
-        public FileIdEnricher(string innerPropertyName)
+        public SearchRequestKeyEnricher(string innerPropertyName)
         {
             this.innerPropertyName = innerPropertyName;
         }
@@ -102,7 +102,7 @@ namespace SearchApi.Web
                 var value = (eventPropertyValue as ScalarValue)?.Value as string;
                 if (!String.IsNullOrEmpty(value))
                 {
-                    logEvent.AddOrUpdateProperty(new LogEventProperty(innerPropertyName, new ScalarValue("FileId:" + value)));
+                    logEvent.AddOrUpdateProperty(new LogEventProperty(innerPropertyName, new ScalarValue("SearchRequestKey:" + value)));
                 }
             }
         }

--- a/app/SearchApi/SearchApi.Web/Search/PersonEventConsumer.cs
+++ b/app/SearchApi/SearchApi.Web/Search/PersonEventConsumer.cs
@@ -25,7 +25,7 @@ namespace SearchApi.Web.Search
 
         public async Task Consume(ConsumeContext<PersonSearchAdapterEvent> context, string eventName)
         {
-            using (LogContext.PushProperty("FileId",context.Message?.FileId))
+            using (LogContext.PushProperty("SearchRequestKey",context.Message?.SearchRequestKey))
             {
                 var cts = new CancellationTokenSource();
                 _logger.LogInformation($"received new {nameof(PersonSearchAdapterEvent)} event from {context.Message.ProviderProfile?.Name}");

--- a/app/SearchApi/SearchApi.Web/Search/PersonEventConsumer.cs
+++ b/app/SearchApi/SearchApi.Web/Search/PersonEventConsumer.cs
@@ -29,7 +29,7 @@ namespace SearchApi.Web.Search
             {
                 var cts = new CancellationTokenSource();
                 _logger.LogInformation($"received new {nameof(PersonSearchAdapterEvent)} event from {context.Message.ProviderProfile?.Name}");
-                await _searchApiNotifier.NotifyEventAsync(context.Message.SearchRequestId, context.Message, eventName,
+                await _searchApiNotifier.NotifyEventAsync(context.Message.SearchRequestKey, context.Message, eventName,
                     cts.Token);
             }
         }

--- a/app/SearchApi/SearchApi.Web/appsettings.json
+++ b/app/SearchApi/SearchApi.Web/appsettings.json
@@ -7,7 +7,7 @@
       {
         "Name": "Console",
         "Args": {
-          "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {FileId}{NewLine}{Exception}"
+          "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {SearchRequestKey}{NewLine}{Exception}"
         }
       }
     ],


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- FAMS3-2249(searchApi-change to use "FileId_Seq ID" as searchRequestKey, not searchApiRequest GUID .)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Tested locally

## Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
