### PR TITLE
Refactor/cleanup radis, make searchRequestKey works in dynadapter personSearchController.

### DIFF
--- a/app/DynamicsAdapter/DynamicsAdapter.Web.Test/PersonSearch/PersonSearchControllerTest.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web.Test/PersonSearch/PersonSearchControllerTest.cs
@@ -26,6 +26,8 @@ namespace DynamicsAdapter.Web.Test.PersonSearch
 
         private Guid _testGuid;
         private Guid _exceptionGuid;
+        private string _searchRequestKey;
+        private string _exceptionSearchRequestKey;
         private string _testFileId;
 
         private PersonSearchController _sut;
@@ -53,6 +55,7 @@ namespace DynamicsAdapter.Web.Test.PersonSearch
         {
             _testGuid = Guid.NewGuid();
             _testFileId = "testFileId";
+            _searchRequestKey = "fileId_SequenceNumber";
             _exceptionGuid = Guid.NewGuid();
             _loggerMock = new Mock<ILogger<PersonSearchController>>();
             _searchApiRequestServiceMock = new Mock<ISearchApiRequestService>();
@@ -113,7 +116,7 @@ namespace DynamicsAdapter.Web.Test.PersonSearch
             _fakePersonAcceptedEvent = new PersonSearchAccepted()
             {
                 SearchRequestId = Guid.NewGuid(),
-                FileId = _testFileId,
+                SearchRequestKey = _searchRequestKey,
                 TimeStamp = DateTime.Now,
                 ProviderProfile = new ProviderProfile()
                 {
@@ -124,7 +127,7 @@ namespace DynamicsAdapter.Web.Test.PersonSearch
             _fakePersonCompletedEvent = new PersonSearchCompleted()
             {
                 SearchRequestId = Guid.NewGuid(),
-                FileId=_testFileId,
+                SearchRequestKey= _searchRequestKey,
                 TimeStamp = DateTime.Now,
                 ProviderProfile = new ProviderProfile()
                 {
@@ -147,7 +150,7 @@ namespace DynamicsAdapter.Web.Test.PersonSearch
             _fakePersonFailedEvent = new PersonSearchFailed()
             {
                 SearchRequestId = Guid.NewGuid(),
-                FileId = _testFileId,
+                SearchRequestKey = _searchRequestKey,
                 TimeStamp = DateTime.Now,
                 ProviderProfile = new ProviderProfile()
                 {
@@ -159,7 +162,7 @@ namespace DynamicsAdapter.Web.Test.PersonSearch
             _fakePersonRejectEvent = new PersonSearchRejected()
             {
                 SearchRequestId = Guid.NewGuid(),
-                FileId = _testFileId,
+                SearchRequestKey = _searchRequestKey,
                 TimeStamp = DateTime.Now,
                 ProviderProfile = new ProviderProfile()
                 {
@@ -171,7 +174,7 @@ namespace DynamicsAdapter.Web.Test.PersonSearch
             _fakePersonFinalizedEvent = new PersonSearchFinalized()
             {
                 SearchRequestId = Guid.NewGuid(),
-                FileId = _testFileId,
+                SearchRequestKey = _searchRequestKey,
                 TimeStamp = DateTime.Now,
                 Message = "test message"
             };
@@ -259,7 +262,7 @@ namespace DynamicsAdapter.Web.Test.PersonSearch
         [Test]
         public async Task With_valid_finalized_event_it_should_return_ok()
         {
-            var result = await _sut.Finalized(_testGuid, _fakePersonFinalizedEvent);
+            var result = await _sut.Finalized(_searchRequestKey, _fakePersonFinalizedEvent);
            _searchApiRequestServiceMock
                 .Verify(x => x.MarkComplete(It.Is<Guid>(x => x == _testGuid), It.IsAny<CancellationToken>()), Times.Once);
             _registerMock.Verify(x => x.RemoveSearchApiRequest(It.IsAny<Guid>()), Times.Once);
@@ -282,7 +285,7 @@ namespace DynamicsAdapter.Web.Test.PersonSearch
         [Test]
         public async Task With_valid_accepted_event_it_should_return_ok()
         {
-            var result = await _sut.Accepted(_testGuid, _fakePersonAcceptedEvent);
+            var result = await _sut.Accepted(_searchRequestKey, _fakePersonAcceptedEvent);
             _searchApiRequestServiceMock
                 .Verify(x => x.AddEventAsync(It.Is<Guid>(x => x == _testGuid), It.IsAny<SSG_SearchApiEvent>(), It.IsAny<CancellationToken>()), Times.Once);
 
@@ -293,7 +296,7 @@ namespace DynamicsAdapter.Web.Test.PersonSearch
         [Test]
         public async Task With_exception_event_it_should_return_badrequest()
         {
-            var result = await _sut.Accepted(_exceptionGuid, null);
+            var result = await _sut.Accepted(_exceptionSearchRequestKey, null);
             Assert.IsInstanceOf(typeof(BadRequestResult), result);
         }
 
@@ -321,7 +324,7 @@ namespace DynamicsAdapter.Web.Test.PersonSearch
         [Test]
         public async Task With_valid_rejected_event_it_should_return_ok()
         {
-            var result = await _sut.Rejected(_testGuid, _fakePersonRejectEvent
+            var result = await _sut.Rejected(_searchRequestKey, _fakePersonRejectEvent
                 );
 
 
@@ -335,7 +338,7 @@ namespace DynamicsAdapter.Web.Test.PersonSearch
         [Test]
         public async Task With_exception_rejected_event_it_should_return_badrequest()
         {
-            var result = await _sut.Rejected(_exceptionGuid, null);
+            var result = await _sut.Rejected(_exceptionSearchRequestKey, null);
             Assert.IsInstanceOf(typeof(BadRequestResult), result);
         }
 

--- a/app/DynamicsAdapter/DynamicsAdapter.Web.Test/PersonSearch/PersonSearchControllerTest.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web.Test/PersonSearch/PersonSearchControllerTest.cs
@@ -47,6 +47,7 @@ namespace DynamicsAdapter.Web.Test.PersonSearch
         private AliasEntity _fakeName;
         private SSG_Person _fakePerson;
         private SSG_Identifier _fakeSourceIdentifier;
+        private SSG_SearchApiRequest _fakeSearchApiRequest;
 
         private Mock<IMapper> _mapper;
 
@@ -56,12 +57,18 @@ namespace DynamicsAdapter.Web.Test.PersonSearch
             _testGuid = Guid.NewGuid();
             _testFileId = "testFileId";
             _searchRequestKey = "fileId_SequenceNumber";
+            _exceptionSearchRequestKey = "exception_seqNum";
             _exceptionGuid = Guid.NewGuid();
             _loggerMock = new Mock<ILogger<PersonSearchController>>();
             _searchApiRequestServiceMock = new Mock<ISearchApiRequestService>();
             _searchResultServiceMock = new Mock<ISearchResultService>();
             _mapper = new Mock<IMapper>();
             _registerMock = new Mock<ISearchRequestRegister>();
+
+            _fakeSearchApiRequest = new SSG_SearchApiRequest()
+            {
+                SearchApiRequestId = _testGuid
+            };
 
             var validRequestId = Guid.NewGuid();
             var invalidRequestId = Guid.NewGuid();
@@ -237,6 +244,9 @@ namespace DynamicsAdapter.Web.Test.PersonSearch
                     It.IsAny<SSG_SearchApiEvent>(), It.IsAny<CancellationToken>()))
                 .Throws(new Exception("random exception"));
 
+            _registerMock.Setup(x => x.GetSearchApiRequest(It.Is<string>(m => m == _searchRequestKey)))
+                .Returns(Task.FromResult(_fakeSearchApiRequest));
+
             _registerMock.Setup(x => x.GetMatchedSourceIdentifier(It.IsAny<PersonalIdentifier>(), It.IsAny<Guid>()))
                 .Returns(Task.FromResult(_fakeSourceIdentifier));
 
@@ -251,7 +261,7 @@ namespace DynamicsAdapter.Web.Test.PersonSearch
         public async Task With_valid_completed_event_it_should_return_ok()
         {
 
-            var result = await _sut.Completed(_testGuid, _fakePersonCompletedEvent);
+            var result = await _sut.Completed(_searchRequestKey, _fakePersonCompletedEvent);
 
             _searchResultServiceMock.Verify(x => x.ProcessPersonFound(It.Is<Person>(x => x.FirstName == "TEST1"), It.IsAny<ProviderProfile>(), It.IsAny<SSG_SearchRequest>(),It.IsAny<Guid>(), It.IsAny<CancellationToken>(),It.IsAny<SSG_Identifier>()), Times.Once);
             _searchApiRequestServiceMock
@@ -265,21 +275,21 @@ namespace DynamicsAdapter.Web.Test.PersonSearch
             var result = await _sut.Finalized(_searchRequestKey, _fakePersonFinalizedEvent);
            _searchApiRequestServiceMock
                 .Verify(x => x.MarkComplete(It.Is<Guid>(x => x == _testGuid), It.IsAny<CancellationToken>()), Times.Once);
-            _registerMock.Verify(x => x.RemoveSearchApiRequest(It.IsAny<Guid>()), Times.Once);
+            _registerMock.Verify(x => x.RemoveSearchApiRequest(It.IsAny<string>()), Times.Once);
             Assert.IsInstanceOf(typeof(OkResult), result);
         }
 
         [Test]
         public async Task With_exception_completed_event_should_return_badrequest()
         {
-            var result = await _sut.Completed(_exceptionGuid, _fakePersonCompletedEvent);
+            var result = await _sut.Completed(_exceptionSearchRequestKey, _fakePersonCompletedEvent);
             Assert.IsInstanceOf(typeof(BadRequestResult), result);
         }
 
         [Test]
         public async Task With_null_completed_event_should_return_bad_request_()
         {
-            var result = await _sut.Completed(_exceptionGuid, null);
+            var result = await _sut.Completed(_exceptionSearchRequestKey, null);
             Assert.IsInstanceOf(typeof(BadRequestResult), result);
         }
         [Test]
@@ -304,7 +314,7 @@ namespace DynamicsAdapter.Web.Test.PersonSearch
         [Test]
         public async Task With_valid_failed_event_it_should_return_ok()
         {
-            var result = await _sut.Failed(_testGuid, _fakePersonFailedEvent);
+            var result = await _sut.Failed(_searchRequestKey, _fakePersonFailedEvent);
 
 
             _searchApiRequestServiceMock
@@ -317,7 +327,7 @@ namespace DynamicsAdapter.Web.Test.PersonSearch
         [Test]
         public async Task With_exception_failed_event_it_should_return_badrequest()
         {
-            var result = await _sut.Failed(_exceptionGuid, null);
+            var result = await _sut.Failed(_exceptionSearchRequestKey, null);
             Assert.IsInstanceOf(typeof(BadRequestResult), result);
         }
 

--- a/app/DynamicsAdapter/DynamicsAdapter.Web.Test/Register/SearchRequestRegisterTest.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web.Test/Register/SearchRequestRegisterTest.cs
@@ -22,9 +22,8 @@ namespace DynamicsAdapter.Web.Test.Register
         private Guid _validSouceIdentifierGuid;
         private Guid _wrongSearchApiRequestGuid;
         private Guid _wrongSourceIdentifierGuid;
-        private string _validFileId;
-        private string _invalidFileId;
-        private string _validSeqNumber;
+        private string _validSearchRequestKey;
+        private string _invalidSearchRequestKey;
         private SSG_SearchApiRequest _fakeRequest;
         private PersonalIdentifier _fakeIdentifier;
         private PersonalIdentifier _wrongIdentifier;
@@ -37,9 +36,8 @@ namespace DynamicsAdapter.Web.Test.Register
             _validSouceIdentifierGuid = Guid.NewGuid();
             _wrongSearchApiRequestGuid = Guid.NewGuid();
             _wrongSourceIdentifierGuid = Guid.NewGuid();
-            _validFileId = "123456";
-            _invalidFileId = "222222";
-            _validSeqNumber = "654321";
+            _validSearchRequestKey = "1234_0000";
+            _invalidSearchRequestKey = "1234_7777";
 
             _fakeRequest = new SSG_SearchApiRequest
             {
@@ -72,19 +70,19 @@ namespace DynamicsAdapter.Web.Test.Register
             _cacheServiceMock.Setup(x => x.Get(It.Is<string>(m => m.ToString() == Keys.REDIS_KEY_PREFIX+_validSearchApiRequestGuid.ToString())))
              .Returns(Task.FromResult(JsonConvert.SerializeObject(_fakeRequest)));
 
-            _cacheServiceMock.Setup(x => x.Get(It.Is<string>(m => m == $"{Keys.REDIS_KEY_PREFIX}{_validFileId}_{_validSeqNumber}")))
+            _cacheServiceMock.Setup(x => x.Get(It.Is<string>(m => m == $"{Keys.REDIS_KEY_PREFIX}{_validSearchRequestKey}")))
             .Returns(Task.FromResult(JsonConvert.SerializeObject(_fakeRequest)));
 
             _cacheServiceMock.Setup(x => x.Delete(It.Is<string>(m => m.ToString() == Keys.REDIS_KEY_PREFIX + _validSearchApiRequestGuid.ToString())))
             .Returns(Task.FromResult(true));
 
-            _cacheServiceMock.Setup(x => x.Delete(It.Is<string>(m => m.ToString() == $"{Keys.REDIS_KEY_PREFIX}{_validFileId}_{_validSeqNumber}")))
+            _cacheServiceMock.Setup(x => x.Delete(It.Is<string>(m => m.ToString() == $"{Keys.REDIS_KEY_PREFIX}{_validSearchRequestKey}")))
             .Returns(Task.FromResult(true));
 
             _cacheServiceMock.Setup(x => x.Get(It.Is<string>(m => m.ToString() == Keys.REDIS_KEY_PREFIX + _wrongSearchApiRequestGuid.ToString())))
              .Returns(Task.FromResult(""));
 
-            _cacheServiceMock.Setup(x => x.Get(It.Is<string>(m => m.ToString() == $"{Keys.REDIS_KEY_PREFIX}{_invalidFileId}_{_validSeqNumber}")))
+            _cacheServiceMock.Setup(x => x.Get(It.Is<string>(m => m.ToString() == $"{Keys.REDIS_KEY_PREFIX}{_validSearchRequestKey}")))
              .Returns(Task.FromResult(""));
 
             _loggerMock = new Mock<ILogger<SearchRequestRegister>>();
@@ -196,7 +194,7 @@ namespace DynamicsAdapter.Web.Test.Register
         [Test]
         public async Task valid_fileId_seqNumber_get_SearchApiRequest_from_cache_correctly()
         {
-            SSG_SearchApiRequest result = await _sut.GetSearchApiRequest(_validFileId, _validSeqNumber);
+            SSG_SearchApiRequest result = await _sut.GetSearchApiRequest(_validSearchRequestKey);
             Assert.AreEqual("111111", result.SearchRequest.FileId);
         }
 
@@ -210,7 +208,7 @@ namespace DynamicsAdapter.Web.Test.Register
         [Test]
         public async Task wrong_fileId_wont_get_searchApiRequest()
         {
-            SSG_SearchApiRequest result = await _sut.GetSearchApiRequest(_invalidFileId, _validSeqNumber);
+            SSG_SearchApiRequest result = await _sut.GetSearchApiRequest(_invalidSearchRequestKey);
             Assert.AreEqual(null, result);
         }
 
@@ -226,7 +224,7 @@ namespace DynamicsAdapter.Web.Test.Register
         [Test]
         public async Task correct_sourceId_validFileId_will_get_correct_ssgIdentifier()
         {
-            SSG_Identifier result = await _sut.GetMatchedSourceIdentifier(_fakeIdentifier, _validFileId, _validSeqNumber);
+            SSG_Identifier result = await _sut.GetMatchedSourceIdentifier(_fakeIdentifier, _validSearchRequestKey);
             Assert.AreEqual(IdentificationType.BirthCertificate.Value, result.IdentifierType);
             Assert.AreEqual("1234567", result.Identification);
             Assert.AreEqual(_validSouceIdentifierGuid, result.IdentifierId);
@@ -242,7 +240,7 @@ namespace DynamicsAdapter.Web.Test.Register
         [Test]
         public async Task wrong_sourceId_validFileId_will_get_null_ssgIdentifier()
         {
-            SSG_Identifier result = await _sut.GetMatchedSourceIdentifier(_wrongIdentifier, _validFileId,_validSeqNumber);
+            SSG_Identifier result = await _sut.GetMatchedSourceIdentifier(_wrongIdentifier, _validSearchRequestKey);
             Assert.AreEqual(null, result);
         }
 
@@ -257,7 +255,7 @@ namespace DynamicsAdapter.Web.Test.Register
         [Test]
         public async Task wrong_fileId_will_get_null_ssgIdentifier()
         {
-            SSG_Identifier result = await _sut.GetMatchedSourceIdentifier(_fakeIdentifier, _invalidFileId, _validSeqNumber);
+            SSG_Identifier result = await _sut.GetMatchedSourceIdentifier(_fakeIdentifier,_invalidSearchRequestKey);
             _loggerMock.VerifyLog(LogLevel.Error, "Cannot find the searchApiRequest in Redis Cache.", Times.Once());
             Assert.AreEqual(null, result);
         }
@@ -272,7 +270,7 @@ namespace DynamicsAdapter.Web.Test.Register
         [Test]
         public async Task valid_fileId_seqNumber_request_will_be_removed_successfully()
         {
-            bool result = await _sut.RemoveSearchApiRequest(_validFileId, _validSeqNumber);
+            bool result = await _sut.RemoveSearchApiRequest(_validSearchRequestKey);
             Assert.AreEqual(true, result);
         }
     }

--- a/app/DynamicsAdapter/DynamicsAdapter.Web.Test/Register/SearchRequestRegisterTest.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web.Test/Register/SearchRequestRegisterTest.cs
@@ -82,7 +82,7 @@ namespace DynamicsAdapter.Web.Test.Register
             _cacheServiceMock.Setup(x => x.Get(It.Is<string>(m => m.ToString() == Keys.REDIS_KEY_PREFIX + _wrongSearchApiRequestGuid.ToString())))
              .Returns(Task.FromResult(""));
 
-            _cacheServiceMock.Setup(x => x.Get(It.Is<string>(m => m.ToString() == $"{Keys.REDIS_KEY_PREFIX}{_validSearchRequestKey}")))
+            _cacheServiceMock.Setup(x => x.Get(It.Is<string>(m => m.ToString() == $"{Keys.REDIS_KEY_PREFIX}{_invalidSearchRequestKey}")))
              .Returns(Task.FromResult(""));
 
             _loggerMock = new Mock<ILogger<SearchRequestRegister>>();

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/PersonSearch/Models/PersonSearchFinalized.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/PersonSearch/Models/PersonSearchFinalized.cs
@@ -5,7 +5,7 @@ namespace DynamicsAdapter.Web.PersonSearch.Models
     public class PersonSearchFinalized
     {
         public Guid SearchRequestId { get; set; }
-        public string FileId { get; set; }
+        public string SearchRequestKey{ get; set; }
         public DateTime TimeStamp { get; set; }
         public string Message { get; set; }
     }

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/PersonSearch/Models/PersonSearchStatus.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/PersonSearch/Models/PersonSearchStatus.cs
@@ -5,7 +5,7 @@ namespace DynamicsAdapter.Web.PersonSearch.Models
     public abstract class PersonSearchStatus
     {
         public Guid SearchRequestId { get; set; }
-        public string FileId { get; set; }
+        public string SearchRequestKey { get; set; }
         public DateTime TimeStamp { get; set; }
         public ProviderProfile ProviderProfile { get; set; }
     }

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/PersonSearch/PersonSearchController.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/PersonSearch/PersonSearchController.cs
@@ -172,7 +172,7 @@ namespace DynamicsAdapter.Web.PersonSearch
         [Produces("application/json")]
         [ProducesResponseType(StatusCodes.Status200OK)]
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
-        [Route("Finalized/{id}")]
+        [Route("Finalized/{key}")]
         [OpenApiTag("Person Search Events API")]
         public async Task<IActionResult> Finalized(string key, [FromBody]PersonSearchFinalized personFinalizedEvent)
         {

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/PersonSearch/PersonSearchController.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/PersonSearch/PersonSearchController.cs
@@ -48,7 +48,7 @@ namespace DynamicsAdapter.Web.PersonSearch
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [Route("Completed/{key}")]
         [OpenApiTag("Person Search Events API")]
-        public async Task<IActionResult> Completed(Guid key, [FromBody]PersonSearchCompleted personCompletedEvent)
+        public async Task<IActionResult> Completed(string key, [FromBody]PersonSearchCompleted personCompletedEvent)
         {
             try
             {
@@ -139,7 +139,7 @@ namespace DynamicsAdapter.Web.PersonSearch
         [ProducesResponseType(StatusCodes.Status400BadRequest)]
         [Route("Failed/{key}")]
         [OpenApiTag("Person Search Events API")]
-        public async Task<IActionResult> Failed(Guid key, [FromBody]PersonSearchFailed personFailedEvent)
+        public async Task<IActionResult> Failed(string key, [FromBody]PersonSearchFailed personFailedEvent)
         {
             using (LogContext.PushProperty("SearchRequestKey", personFailedEvent?.SearchRequestKey))
             using (LogContext.PushProperty("DataPartner", personFailedEvent?.ProviderProfile.Name))

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/Program.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/Program.cs
@@ -44,7 +44,7 @@ namespace DynamicsAdapter.Web
                 {
                     loggerConfiguration
                         .ReadFrom.Configuration(hostingContext.Configuration)
-                        .Enrich.WithPropertyFileId("FileId")
+                        .Enrich.WithPropertySearchRequestKey("SearchRequestKey")
                         .Enrich.WithPropertyDataPartner("DataPartner")
                         .Enrich.FromLogContext();
 
@@ -75,9 +75,9 @@ namespace DynamicsAdapter.Web
 
     public static class EnrichersExtensions
     {
-        public static LoggerConfiguration WithPropertyFileId(this LoggerEnrichmentConfiguration enrichmentConfiguration, string propertyName)
+        public static LoggerConfiguration WithPropertySearchRequestKey(this LoggerEnrichmentConfiguration enrichmentConfiguration, string propertyName)
         {
-            return enrichmentConfiguration.With(new FileIdEnricher(propertyName));
+            return enrichmentConfiguration.With(new SearchRequestKeyEnricher(propertyName));
         }
 
         public static LoggerConfiguration WithPropertyDataPartner(this LoggerEnrichmentConfiguration enrichmentConfiguration, string propertyName)
@@ -87,11 +87,11 @@ namespace DynamicsAdapter.Web
 
     }
 
-    public class FileIdEnricher : ILogEventEnricher
+    public class SearchRequestKeyEnricher : ILogEventEnricher
     {
         private readonly string innerPropertyName;
 
-        public FileIdEnricher(string innerPropertyName)
+        public SearchRequestKeyEnricher(string innerPropertyName)
         {
             this.innerPropertyName = innerPropertyName;
         }
@@ -104,7 +104,7 @@ namespace DynamicsAdapter.Web
                 var value = (eventPropertyValue as ScalarValue)?.Value as string;
                 if (!String.IsNullOrEmpty(value))
                 {
-                    logEvent.AddOrUpdateProperty(new LogEventProperty(innerPropertyName, new ScalarValue("FileId:"+value)));
+                    logEvent.AddOrUpdateProperty(new LogEventProperty(innerPropertyName, new ScalarValue("SearchRequestKey:" + value)));
                 }
             }
         }

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/Register/SearchRequestRegister.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/Register/SearchRequestRegister.cs
@@ -15,7 +15,9 @@ namespace DynamicsAdapter.Web.Register
         SSG_SearchApiRequest FilterDuplicatedIdentifier(SSG_SearchApiRequest request);
         Task<bool> RegisterSearchApiRequest(SSG_SearchApiRequest request);
         Task<SSG_SearchApiRequest> GetSearchApiRequest(Guid guid);
+        Task<SSG_SearchApiRequest> GetSearchApiRequest(string searchRequestKey);
         Task<bool> RemoveSearchApiRequest(Guid guid);
+        Task<bool> RemoveSearchApiRequest(string searchRequestKey);
         Task<SSG_Identifier> GetMatchedSourceIdentifier(PersonalIdentifier identifer, Guid searchApiRequestId);
     }
 
@@ -47,9 +49,9 @@ namespace DynamicsAdapter.Web.Register
             return true;
         }
 
-        public async Task<SSG_SearchApiRequest> GetSearchApiRequest(string fileId, string sequenceNumber)
+        public async Task<SSG_SearchApiRequest> GetSearchApiRequest(string searchRequestKey)
         {
-            string data = await _cache.Get($"{Keys.REDIS_KEY_PREFIX}{fileId}_{sequenceNumber}");
+            string data = await _cache.Get($"{Keys.REDIS_KEY_PREFIX}{searchRequestKey}");
             if (String.IsNullOrEmpty(data)) return null;
             return JsonConvert.DeserializeObject<SSG_SearchApiRequest>(data);
         }
@@ -76,9 +78,9 @@ namespace DynamicsAdapter.Web.Register
                      && m.IdentifierType == type);
         }
 
-        public async Task<SSG_Identifier> GetMatchedSourceIdentifier(PersonalIdentifier identifer, string fileId, string sequenceNumber)
+        public async Task<SSG_Identifier> GetMatchedSourceIdentifier(PersonalIdentifier identifer, string searchRequestKey)
         {
-            SSG_SearchApiRequest searchApiReqeust = await GetSearchApiRequest(fileId, sequenceNumber);
+            SSG_SearchApiRequest searchApiReqeust = await GetSearchApiRequest(searchRequestKey);
             if (searchApiReqeust == null)
             {
                 _logger.LogError("Cannot find the searchApiRequest in Redis Cache.");
@@ -97,9 +99,9 @@ namespace DynamicsAdapter.Web.Register
             return true;
         }
 
-        public async Task<bool> RemoveSearchApiRequest(string fileId, string sequenceNumber)
+        public async Task<bool> RemoveSearchApiRequest(string searchRequestKey)
         {
-            await _cache.Delete($"{Keys.REDIS_KEY_PREFIX}{fileId}_{sequenceNumber}");
+            await _cache.Delete($"{Keys.REDIS_KEY_PREFIX}{searchRequestKey}");
             return true;
         }
     }

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/Register/SearchRequestRegister.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/Register/SearchRequestRegister.cs
@@ -18,6 +18,7 @@ namespace DynamicsAdapter.Web.Register
         Task<SSG_SearchApiRequest> GetSearchApiRequest(string searchRequestKey);
         Task<bool> RemoveSearchApiRequest(Guid guid);
         Task<bool> RemoveSearchApiRequest(string searchRequestKey);
+        Task<SSG_Identifier> GetMatchedSourceIdentifier(PersonalIdentifier identifer, string searchReqeustKey);
         Task<SSG_Identifier> GetMatchedSourceIdentifier(PersonalIdentifier identifer, Guid searchApiRequestId);
     }
 

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/SearchRequest/SearchRequestJob.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/SearchRequest/SearchRequestJob.cs
@@ -59,7 +59,7 @@ namespace DynamicsAdapter.Web.SearchRequest
                     {
                         try
                         {
-                            using (LogContext.PushProperty("FileId", ssgSearchRequest.SearchRequest?.FileId))
+                            using (LogContext.PushProperty("SearchRequestKey", $"{ssgSearchRequest.SearchRequest?.FileId}_{ssgSearchRequest.SequenceNumber}"))
                             {
                                 _logger.LogDebug(
                                    $"Attempting to post person search for request {ssgSearchRequest.SearchApiRequestId}");

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/appsettings.json
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/appsettings.json
@@ -14,7 +14,7 @@
       {
         "Name": "Console",
         "Args": {
-          "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {FileId} {DataPartner}{NewLine}{Exception}"
+          "outputTemplate": "[{Timestamp:HH:mm:ss} {Level:u3}] {Message:lj} {SearchRequestKey} {DataPartner}{NewLine}{Exception}"
         }
       }
     ],

--- a/app/DynamicsAdapter/DynamicsAdapter.sln
+++ b/app/DynamicsAdapter/DynamicsAdapter.sln
@@ -15,10 +15,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Fams3Adapter.Dynamics", "Fa
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Fams3Adapter.Dynamics.Test", "Fams3Adapter.Dynamics.Test\Fams3Adapter.Dynamics.Test.csproj", "{F0A1BDFD-08C2-4A1E-A6CB-BD996B2274CF}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BcGov.Fams3.Redis", "..\SearchApi\BcGov.Fams3.Redis\BcGov.Fams3.Redis.csproj", "{64468F81-A11E-4849-8AB3-22168A4E3A86}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BcGov.Fams3.Redis.Test", "..\SearchApi\BcGov.Fams3.Redis.Test\BcGov.Fams3.Redis.Test.csproj", "{B65A6F0F-8BBA-4201-9292-332A521A417B}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -41,14 +37,6 @@ Global
 		{F0A1BDFD-08C2-4A1E-A6CB-BD996B2274CF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F0A1BDFD-08C2-4A1E-A6CB-BD996B2274CF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F0A1BDFD-08C2-4A1E-A6CB-BD996B2274CF}.Release|Any CPU.Build.0 = Release|Any CPU
-		{64468F81-A11E-4849-8AB3-22168A4E3A86}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{64468F81-A11E-4849-8AB3-22168A4E3A86}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{64468F81-A11E-4849-8AB3-22168A4E3A86}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{64468F81-A11E-4849-8AB3-22168A4E3A86}.Release|Any CPU.Build.0 = Release|Any CPU
-		{B65A6F0F-8BBA-4201-9292-332A521A417B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{B65A6F0F-8BBA-4201-9292-332A521A417B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{B65A6F0F-8BBA-4201-9292-332A521A417B}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{B65A6F0F-8BBA-4201-9292-332A521A417B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -58,8 +46,6 @@ Global
 		{6283EFDD-21EC-4FE5-B01E-54588BBB8FCD} = {1BE19189-029E-4D64-973E-9885F1F82B08}
 		{64CD5D00-7677-4F3B-BBAA-8F70B68DB4A7} = {8E50E690-382C-414E-AC59-30874FA77929}
 		{F0A1BDFD-08C2-4A1E-A6CB-BD996B2274CF} = {1BE19189-029E-4D64-973E-9885F1F82B08}
-		{64468F81-A11E-4849-8AB3-22168A4E3A86} = {8E50E690-382C-414E-AC59-30874FA77929}
-		{B65A6F0F-8BBA-4201-9292-332A521A417B} = {1BE19189-029E-4D64-973E-9885F1F82B08}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {6CE74247-B29B-4644-BC6F-79C7B36D2C2C}

--- a/app/SearchApi/BcGov.Fams3.SearchApi.Contracts/BcGov.Fams3.SearchApi.Contracts.csproj
+++ b/app/SearchApi/BcGov.Fams3.SearchApi.Contracts/BcGov.Fams3.SearchApi.Contracts.csproj
@@ -2,15 +2,15 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
-    <Version>1.0.35</Version>
+    <Version>1.0.36</Version>
     <Authors>PathFinder</Authors>
     <Company>BcGov</Company>
     <Description />
-    <PackageVersion>1.0.35</PackageVersion>
+    <PackageVersion>1.0.36</PackageVersion>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <AssemblyVersion>1.0.35.0</AssemblyVersion>
-    <FileVersion>1.0.35.0</FileVersion>
+    <AssemblyVersion>1.0.36.0</AssemblyVersion>
+    <FileVersion>1.0.36.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/app/SearchApi/BcGov.Fams3.SearchApi.Contracts/PersonSearch/PersonSearchReceived.cs
+++ b/app/SearchApi/BcGov.Fams3.SearchApi.Contracts/PersonSearch/PersonSearchReceived.cs
@@ -6,6 +6,6 @@ namespace BcGov.Fams3.SearchApi.Contracts.PersonSearch
 {
    public interface PersonSearchReceived : PersonSearchEvent
     {
-        string ReceivedPayload { get; }
+        object ReceivedPayload { get; }
     }
 }

--- a/app/SearchApi/BcGov.Fams3.SearchApi.Core/BcGov.Fams3.SearchApi.Core.csproj
+++ b/app/SearchApi/BcGov.Fams3.SearchApi.Core/BcGov.Fams3.SearchApi.Core.csproj
@@ -5,8 +5,8 @@
     <Authors>PathFinder</Authors>
     <Company>BcGov</Company>
     <Description>A core Librairy for BCGOV SearchApi Related Products</Description>
-    <Version>1.0.35</Version>
-    <PackageVersion>1.0.35</PackageVersion>
+    <Version>1.0.36</Version>
+    <PackageVersion>1.0.36</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/app/SearchApi/SearchAdapter.Sample.Test/SearchResultConsumerTest.cs
+++ b/app/SearchApi/SearchAdapter.Sample.Test/SearchResultConsumerTest.cs
@@ -33,7 +33,7 @@ namespace SearchAdapter.Sample.Test
             public DateTime TimeStamp { get; set; }
             public string SearchRequestKey { get; set; }
 
-            public string ReceivedPayload { get; set; }
+            public object ReceivedPayload { get; set; }
 
 
         }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

-FAMS3-2248 (dynadapter-save fileID, seq id and searchApi guid to cache. use fileID and seqID as id in contract.)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Tested locally

## Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
