### PR TITLE
fix issue about sourceIdentifier filtering. We should not compare issuedBy.

### DIFF
--- a/app/DynamicsAdapter/DynamicsAdapter.Web.Test/Register/SearchRequestRegisterTest.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web.Test/Register/SearchRequestRegisterTest.cs
@@ -160,6 +160,13 @@ namespace DynamicsAdapter.Web.Test.Register
                         new SSG_Identifier()
                         {
                             Identification = "1234567",
+                            IdentifierType = IdentificationType.BCDriverLicense.Value,
+                            IssuedBy = "request",
+                            IdentifierId=Guid.NewGuid()
+                        },
+                        new SSG_Identifier()
+                        {
+                            Identification = "1234567",
                             IdentifierType = IdentificationType.BirthCertificate.Value,
                             IssuedBy = "bc",
                             IdentifierId=Guid.NewGuid()

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/Register/SearchRequestRegister.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/Register/SearchRequestRegister.cs
@@ -36,7 +36,7 @@ namespace DynamicsAdapter.Web.Register
         public SSG_SearchApiRequest FilterDuplicatedIdentifier(SSG_SearchApiRequest request)
         {
             SSG_Identifier[] uniqueIdentifers = request.Identifiers
-                               .GroupBy(x => (x.Identification, x.IdentifierType, x.IssuedBy?.ToLower()))
+                               .GroupBy(x => (x.Identification, x.IdentifierType))
                                .Select(y => y.First()).ToArray<SSG_Identifier>();
 
             request.Identifiers = uniqueIdentifers;


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- this is a bug found during sprint20 review planning

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Tested locally

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
