### PR TITLE
dynadapter and request adaptor return submitted event to Inbound searchRequest adaptor.

### DIFF
--- a/app/DynamicsAdapter/DynamicsAdapter.Web.Test/SearchAgency/AgencyRequestServiceTest.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web.Test/SearchAgency/AgencyRequestServiceTest.cs
@@ -275,7 +275,7 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
         [Test]
         public async Task normal_searchRequestOrdered_ProcessSearchRequestOrdered_should_succeed()
         {
-            bool result = await _sut.ProcessSearchRequestOrdered(_searchRequstOrdered);
+            SSG_SearchRequest ssgSearchRequest = await _sut.ProcessSearchRequestOrdered(_searchRequstOrdered);
             _searchRequestServiceMock.Verify( m=>m.CreateSearchRequest(It.IsAny<SearchRequestEntity>(), It.IsAny<CancellationToken>()),Times.Once );
             _searchRequestServiceMock.Verify(m => m.SavePerson(It.IsAny<PersonEntity>(), It.IsAny<CancellationToken>()), Times.Once);
             _searchRequestServiceMock.Verify(m => m.CreateIdentifier(It.IsAny<IdentifierEntity>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
@@ -310,7 +310,7 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
                 SearchRequestKey = "key",
                 Person = nullPerson
             };
-            bool result = await _sut.ProcessSearchRequestOrdered(searchRequstOrdered);
+            SSG_SearchRequest ssgSearchRequest = await _sut.ProcessSearchRequestOrdered(searchRequstOrdered);
             _searchRequestServiceMock.Verify(m => m.CreateSearchRequest(It.IsAny<SearchRequestEntity>(), It.IsAny<CancellationToken>()), Times.Once);
             _searchRequestServiceMock.Verify(m => m.SavePerson(It.IsAny<PersonEntity>(), It.IsAny<CancellationToken>()), Times.Once);
             _searchRequestServiceMock.Verify(m => m.CreateIdentifier(It.IsAny<IdentifierEntity>(), It.IsAny<CancellationToken>()), Times.Never);

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/AgencyRequestController.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/AgencyRequestController.cs
@@ -1,3 +1,4 @@
+using DynamicsAdapter.Web.PersonSearch.Models;
 using DynamicsAdapter.Web.SearchAgency.Models;
 using Fams3Adapter.Dynamics.SearchRequest;
 using Microsoft.AspNetCore.Http;
@@ -87,8 +88,11 @@ namespace DynamicsAdapter.Web.SearchAgency
                 SearchRequestId = createdSearchRequest.SearchRequestId,
                 TimeStamp = DateTime.Now,
                 EstimatedCompletion = DateTime.Now.AddDays(60), //todo: need to implement when design is ready.
-                QueuePosition = 4,
-                Message = $"The new Search Request reference: {requestOrdered.RequestId} has been submitted successfully."
+                QueuePosition = 4,//todo: need to implement when design is ready.
+                Message = $"The new Search Request reference: {requestOrdered.RequestId} has been submitted successfully.",
+                ProviderProfile = new ProviderProfile() {
+                    Name= requestOrdered?.Person?.Agency?.Code
+                }
             };
         }
     }

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/AgencyRequestController.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/AgencyRequestController.cs
@@ -1,4 +1,5 @@
 using DynamicsAdapter.Web.SearchAgency.Models;
+using Fams3Adapter.Dynamics.SearchRequest;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -37,8 +38,9 @@ namespace DynamicsAdapter.Web.SearchAgency
             if (searchRequestOrdered.Action != RequestAction.NEW) return BadRequest();
             try
             {
-                await _agencyRequestService.ProcessSearchRequestOrdered(searchRequestOrdered);
-                return Ok();
+                SSG_SearchRequest createdSearchRequest = await _agencyRequestService.ProcessSearchRequestOrdered(searchRequestOrdered);
+                 
+                return Ok(BuildSearchRequestSubmitted(createdSearchRequest, searchRequestOrdered));
             }
             catch (Exception ex)
             {
@@ -73,6 +75,21 @@ namespace DynamicsAdapter.Web.SearchAgency
             //todo: Not implemented yet.
             await Task.Delay(1);
             return Ok();
+        }
+
+        private SearchRequestSubmitted BuildSearchRequestSubmitted(SSG_SearchRequest createdSearchRequest, SearchRequestOrdered requestOrdered)
+        {
+            return new SearchRequestSubmitted()
+            {
+                Action = requestOrdered.Action,
+                RequestId = requestOrdered.RequestId,
+                SearchRequestKey = createdSearchRequest.FileId,
+                SearchRequestId = createdSearchRequest.SearchRequestId,
+                TimeStamp = DateTime.Now,
+                EstimatedCompletion = DateTime.Now.AddDays(60), //todo: need to implement when design is ready.
+                QueuePosition = 4,
+                Message = $"The new Search Request reference: {requestOrdered.RequestId} has been submitted successfully."
+            };
         }
     }
 }

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/AgencyRequestService.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/AgencyRequestService.cs
@@ -18,7 +18,7 @@ namespace DynamicsAdapter.Web.SearchAgency
 {
     public interface IAgencyRequestService
     {
-        Task<bool> ProcessSearchRequestOrdered(SearchRequestOrdered searchRequestOrdered);
+        Task<SSG_SearchRequest> ProcessSearchRequestOrdered(SearchRequestOrdered searchRequestOrdered);
     }
 
     public class AgencyRequestService : IAgencyRequestService
@@ -41,7 +41,7 @@ namespace DynamicsAdapter.Web.SearchAgency
             _uploadedSearchRequest = null;
         }
 
-        public async Task<bool> ProcessSearchRequestOrdered(SearchRequestOrdered searchRequestOrdered)
+        public async Task<SSG_SearchRequest> ProcessSearchRequestOrdered(SearchRequestOrdered searchRequestOrdered)
         {
             _personSought = searchRequestOrdered.Person;
             var cts = new CancellationTokenSource();
@@ -61,7 +61,7 @@ namespace DynamicsAdapter.Web.SearchAgency
             await UploadPhones();
             await UploadEmployment();
             await UploadRelatedPersons();
-            return true;
+            return _uploadedSearchRequest;
         }
 
         private async Task<bool> UploadIdentifiers()

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/Models/SearchRequestEvent.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/Models/SearchRequestEvent.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace DynamicsAdapter.Web.SearchAgency.Models
 {
@@ -25,6 +22,7 @@ namespace DynamicsAdapter.Web.SearchAgency.Models
         ///   action requested by agency, new, update, cancel, notify"
         /// </summary>
         public RequestAction Action { get; set; }
+        public DynamicsAdapter.Web.PersonSearch.Models.ProviderProfile ProviderProfile { get; set; }
     }
 
     public enum RequestAction

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/Models/SearchRequestSubmitted.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/Models/SearchRequestSubmitted.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace DynamicsAdapter.Web.SearchAgency.Models
+{
+    public class SearchRequestSubmitted : SearchRequestEvent
+    {
+        public string Message { get; set; }
+        public int QueuePosition { get; set; }
+        public DateTime EstimatedCompletion { get; set; }
+    }
+}

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/Startup.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/Startup.cs
@@ -35,7 +35,6 @@ using Quartz.Spi;
 using Simple.OData.Client;
 using System;
 using System.Collections.Generic;
-using System.Net.Http;
 
 namespace DynamicsAdapter.Web
 {

--- a/app/SearchApi/BcGov.Fams3.SearchApi.Contracts/SearchRequest/SearchRequestEvent.cs
+++ b/app/SearchApi/BcGov.Fams3.SearchApi.Contracts/SearchRequest/SearchRequestEvent.cs
@@ -9,11 +9,11 @@ namespace BcGov.Fams3.SearchApi.Contracts.SearchRequest
 
     {
         /// <summary>
-        /// This is Data Partner Id for the SearchRequest
+        /// This is the agency search request Id for the SearchRequest
         /// </summary>
         string RequestId { get; }
         /// <summary>
-        /// This is the Key to identify the searchRequest in dynamics it is made of FileId_SequenceNumber
+        /// This is the Key to identify the searchRequest in dynamics it is FileId
         /// </summary>
         string SearchRequestKey { get; }
         /// <summary>
@@ -23,7 +23,7 @@ namespace BcGov.Fams3.SearchApi.Contracts.SearchRequest
         DateTime TimeStamp { get; }
         ////
         /// <summary>
-        ///   action requested by agency, new, update, cancel, notify"
+        ///   action requested by agency, new, update, cancel, notify
         /// </summary>
         public RequestAction Action { get; set; }
 

--- a/app/SearchApi/SearchRequest.Adaptor.Test/Notifier/SearchRequestNotifierTest.cs
+++ b/app/SearchApi/SearchRequest.Adaptor.Test/Notifier/SearchRequestNotifierTest.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 using SearchRequestAdaptor.Configuration;
 using SearchRequestAdaptor.Notifier;
 using SearchRequestAdaptor.Publisher;
+using SearchRequestAdaptor.Publisher.Models;
 using System;
 using System.Collections.Generic;
 using System.Net;
@@ -92,7 +93,7 @@ namespace SearchRequest.Adaptor.Test.Notifier
 
             _searchRquestEventPublisherMock.Verify(
                 x => x.PublishSearchRequestSubmitted(
-                It.IsAny<SearchRequestEvent>(), It.IsAny<string>()), Times.Once);
+                It.IsAny<SearchRequestSubmittedEvent>()), Times.Once);
         }
 
 

--- a/app/SearchApi/SearchRequest.Adaptor.Test/Notifier/SearchRequestNotifierTest.cs
+++ b/app/SearchApi/SearchRequest.Adaptor.Test/Notifier/SearchRequestNotifierTest.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using Moq.Protected;
+using Newtonsoft.Json;
 using NUnit.Framework;
 using SearchRequestAdaptor.Configuration;
 using SearchRequestAdaptor.Notifier;
@@ -13,7 +14,6 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -55,10 +55,18 @@ namespace SearchRequest.Adaptor.Test.Notifier
                 .ReturnsAsync(new HttpResponseMessage()
                 {
                     StatusCode = HttpStatusCode.OK,
-                    Content = new StringContent("worked!"),
+                    Content = new StringContent(JsonConvert.SerializeObject(
+                        new SearchRequestSubmittedEvent()
+                        {
+                            SearchRequestId = Guid.NewGuid(),
+                            SearchRequestKey = "fileId",
+                            RequestId = "requestId",
+                            ProviderProfile = new SearchRequest.Adaptor.Publisher.Models.ProviderProfile() { Name = "AgencyName" }
+                        })),
                 })
                 .Verifiable();
-            _httpClient= new HttpClient(_httpHandlerMock.Object);
+
+            _httpClient = new HttpClient(_httpHandlerMock.Object);
             _fakeSearchRequestOrdered = new FakeSearchRequestOrdered()
             {
                 Action = BcGov.Fams3.SearchApi.Contracts.Person.RequestAction.NEW,
@@ -142,9 +150,9 @@ namespace SearchRequest.Adaptor.Test.Notifier
                 .Verifiable();
 
             _sut = new WebHookSearchRequestNotifier(_httpClient, _searchRequestOptionsMock.Object, _loggerMock.Object, _searchRquestEventPublisherMock.Object);
-           await _sut.NotifySearchRequestEventAsync(
-                    _fakeSearchRequestOrdered.RequestId,
-                    _fakeSearchRequestOrdered, CancellationToken.None);
+            await _sut.NotifySearchRequestEventAsync(
+                     _fakeSearchRequestOrdered.RequestId,
+                     _fakeSearchRequestOrdered, CancellationToken.None);
 
             _httpHandlerMock.Protected().Verify(
                     "SendAsync",
@@ -193,7 +201,7 @@ namespace SearchRequest.Adaptor.Test.Notifier
         {
             _sut = new WebHookSearchRequestNotifier(_httpClient, _searchRequestOptionsMock.Object, _loggerMock.Object, _searchRquestEventPublisherMock.Object);
 
-            Assert.ThrowsAsync<ArgumentNullException>(() =>  _sut.NotifySearchRequestEventAsync(
+            Assert.ThrowsAsync<ArgumentNullException>(() => _sut.NotifySearchRequestEventAsync(
                 _fakeSearchRequestOrdered.RequestId,
                 null, CancellationToken.None));
 

--- a/app/SearchApi/SearchRequest.Adaptor.Test/Publisher/SearchRequestEventPublisherTest.cs
+++ b/app/SearchApi/SearchRequest.Adaptor.Test/Publisher/SearchRequestEventPublisherTest.cs
@@ -90,15 +90,16 @@ namespace SearchRequest.Adaptor.Test.Publisher
         [Test]
         public async Task PublishSearchRequestSubmitted_should_pubish_submittedEvent()
         {
-            await _sut.PublishSearchRequestSubmitted(_baseEvent, "submitted");
+            SearchRequestSubmittedEvent submittedEvent = new SearchRequestSubmittedEvent();
+            await _sut.PublishSearchRequestSubmitted(submittedEvent);
             _sendEndpointMock.Verify(x => x.Send<SearchRequestSubmitted>(It.IsAny<SearchRequestSubmittedEvent>(), It.IsAny<CancellationToken>()),
                 () => { return Times.Once(); });
         }
 
         [Test]
-        public void with_null_baseEvent_PublishSearchRequestSubmitted_should_throw_exception()
+        public void with_null_submittedEvent_PublishSearchRequestSubmitted_should_throw_exception()
         {
-            Assert.ThrowsAsync<ArgumentNullException>(() => _sut.PublishSearchRequestSubmitted(null, "submitted"));
+            Assert.ThrowsAsync<ArgumentNullException>(() => _sut.PublishSearchRequestSubmitted(null));
         }
 
         [Test]

--- a/app/SearchApi/SearchRequest.Adaptor/Notifier/SearchRequestNotifier.cs
+++ b/app/SearchApi/SearchRequest.Adaptor/Notifier/SearchRequestNotifier.cs
@@ -98,11 +98,12 @@ namespace SearchRequestAdaptor.Notifier
                     }
 
                     string responseContent = await response.Content.ReadAsStringAsync();
-                    SearchRequestSubmitted submitted = (SearchRequestSubmitted)JsonConvert.DeserializeObject(responseContent);
+                    var submitted = JsonConvert.DeserializeObject<SearchRequestSubmittedEvent>(responseContent);
                     
                     _logger.LogInformation(
                         $"The webHook {webHookName} notification has executed status {eventName} successfully for {webHook.Name} webHook.");
-                    await _searchRequestEventPublisher.PublishSearchRequestSubmitted(submitted, "Search Request has been submitted successfully.");
+                    
+                    await _searchRequestEventPublisher.PublishSearchRequestSubmitted(submitted);
                 }
                 catch (Exception exception)
                 {

--- a/app/SearchApi/SearchRequest.Adaptor/Notifier/SearchRequestNotifier.cs
+++ b/app/SearchApi/SearchRequest.Adaptor/Notifier/SearchRequestNotifier.cs
@@ -97,9 +97,12 @@ namespace SearchRequestAdaptor.Notifier
                         return;
                     }
 
+                    string responseContent = await response.Content.ReadAsStringAsync();
+                    SearchRequestSubmitted submitted = (SearchRequestSubmitted)JsonConvert.DeserializeObject(responseContent);
+                    
                     _logger.LogInformation(
                         $"The webHook {webHookName} notification has executed status {eventName} successfully for {webHook.Name} webHook.");
-                    await _searchRequestEventPublisher.PublishSearchRequestSubmitted(searchRequestOrdered, "Search Request has been submitted successfully.");
+                    await _searchRequestEventPublisher.PublishSearchRequestSubmitted(submitted, "Search Request has been submitted successfully.");
                 }
                 catch (Exception exception)
                 {

--- a/app/SearchApi/SearchRequest.Adaptor/Publisher/Models/ProviderProfile.cs
+++ b/app/SearchApi/SearchRequest.Adaptor/Publisher/Models/ProviderProfile.cs
@@ -1,0 +1,9 @@
+﻿using BcGov.Fams3.SearchApi.Contracts.PersonSearch;
+
+namespace SearchRequest.Adaptor.Publisher.Models
+{
+    public class ProviderProfile
+    {
+        public string Name { get; set; }
+    }
+}

--- a/app/SearchApi/SearchRequest.Adaptor/Publisher/Models/SearchRequestSubmittedEvent.cs
+++ b/app/SearchApi/SearchRequest.Adaptor/Publisher/Models/SearchRequestSubmittedEvent.cs
@@ -1,11 +1,11 @@
-﻿using BcGov.Fams3.SearchApi.Contracts.Person;
-using BcGov.Fams3.SearchApi.Contracts.PersonSearch;
+using BcGov.Fams3.SearchApi.Contracts.Person;
 using BcGov.Fams3.SearchApi.Contracts.SearchRequest;
+using SearchRequest.Adaptor.Publisher.Models;
 using System;
 
 namespace SearchRequestAdaptor.Publisher.Models
 {
-    public class SearchRequestSubmittedEvent : SearchRequestSubmitted
+    public class SearchRequestSubmittedEvent 
     {
         public SearchRequestSubmittedEvent(SearchRequestEvent baseEvent)
         {

--- a/app/SearchApi/SearchRequest.Adaptor/Publisher/Models/SearchRequestSubmittedEvent.cs
+++ b/app/SearchApi/SearchRequest.Adaptor/Publisher/Models/SearchRequestSubmittedEvent.cs
@@ -16,6 +16,10 @@ namespace SearchRequestAdaptor.Publisher.Models
             this.Action = baseEvent.Action;
         }
 
+        public SearchRequestSubmittedEvent()
+        {           
+        }
+
         public string RequestId { get; set; }
 
         public string SearchRequestKey { get; set; }

--- a/app/SearchApi/SearchRequest.Adaptor/Publisher/SearchRequestEventPublisher.cs
+++ b/app/SearchApi/SearchRequest.Adaptor/Publisher/SearchRequestEventPublisher.cs
@@ -15,7 +15,7 @@ namespace SearchRequestAdaptor.Publisher
     public interface ISearchRequestEventPublisher
     {
         public Task PublishSearchRequestFailed(SearchRequestEvent baseEvent, string message);
-        public Task PublishSearchRequestSubmitted(SearchRequestEvent baseEvent, string message);
+        public Task PublishSearchRequestSubmitted(SearchRequestSubmitted submittedEvent);
         public Task PublishSearchRequestRejected(SearchRequestEvent baseEvent, IEnumerable<ValidationResult> reasons);
 
     }
@@ -57,16 +57,13 @@ namespace SearchRequestAdaptor.Publisher
             });
         }
 
-        public async Task PublishSearchRequestSubmitted(SearchRequestEvent baseEvent, string message)
+        public async Task PublishSearchRequestSubmitted(SearchRequestSubmitted submittedEvent)
         {
-            if (baseEvent == null) throw new ArgumentNullException(nameof(SearchRequestEvent));
+            if (submittedEvent == null) throw new ArgumentNullException(nameof(SearchRequestSubmitted));
 
             var endpoint = await _sendEndpointProvider.GetSendEndpoint(new Uri($"rabbitmq://{this._rabbitMqConfiguration.Host}:{this._rabbitMqConfiguration.Port}/SearchRequestSubmitted_queue"));
 
-            await endpoint.Send<SearchRequestSubmitted>(new SearchRequestSubmittedEvent(baseEvent)
-            {
-                Message = message
-            });
+            await endpoint.Send<SearchRequestSubmitted>(submittedEvent);
         }
     }
 }

--- a/app/SearchApi/SearchRequest.Adaptor/Publisher/SearchRequestEventPublisher.cs
+++ b/app/SearchApi/SearchRequest.Adaptor/Publisher/SearchRequestEventPublisher.cs
@@ -15,7 +15,7 @@ namespace SearchRequestAdaptor.Publisher
     public interface ISearchRequestEventPublisher
     {
         public Task PublishSearchRequestFailed(SearchRequestEvent baseEvent, string message);
-        public Task PublishSearchRequestSubmitted(SearchRequestSubmitted submittedEvent);
+        public Task PublishSearchRequestSubmitted(SearchRequestSubmittedEvent submittedEvent);
         public Task PublishSearchRequestRejected(SearchRequestEvent baseEvent, IEnumerable<ValidationResult> reasons);
 
     }
@@ -57,7 +57,7 @@ namespace SearchRequestAdaptor.Publisher
             });
         }
 
-        public async Task PublishSearchRequestSubmitted(SearchRequestSubmitted submittedEvent)
+        public async Task PublishSearchRequestSubmitted(SearchRequestSubmittedEvent submittedEvent)
         {
             if (submittedEvent == null) throw new ArgumentNullException(nameof(SearchRequestSubmitted));
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

-FAMS3-2504( Dynadapter send submitted response back to request adaptor.)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Tested locally and unit tests

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
