### PR TITLE
submitted event and cancel search request

### DIFF
--- a/app/DynamicsAdapter/DynamicsAdapter.Web.Test/SearchAgency/AgencyRequestControllerTest.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web.Test/SearchAgency/AgencyRequestControllerTest.cs
@@ -26,7 +26,7 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
         }
 
         [Test]
-        public async Task With_valid_searchRequestOrdered_it_should_return_ok_with_correct_content()
+        public async Task With_valid_searchRequestOrdered_CreateSearchRequest_should_return_ok_with_correct_content()
         {
             SearchRequestOrdered validSearchRequestOrdered = new SearchRequestOrdered()
             {
@@ -62,7 +62,7 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
         }
 
         [Test]
-        public async Task With_null_key_searchRequestOrdered_it_should_return_BadRequest()
+        public async Task With_null_key_searchRequestOrdered_CreateSearchRequest_should_return_BadRequest()
         {
             SearchRequestOrdered validSearchRequestOrdered = new SearchRequestOrdered()
             {
@@ -73,11 +73,11 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
             var result = await _sut.CreateSearchRequest(null, validSearchRequestOrdered);
 
             _agencyRequestServiceMock.Verify(x => x.ProcessSearchRequestOrdered(It.IsAny<SearchRequestOrdered>()), Times.Never);
-            Assert.IsInstanceOf(typeof(BadRequestResult), result);
+            Assert.IsInstanceOf(typeof(BadRequestObjectResult), result);
         }
 
         [Test]
-        public async Task With_update_action_searchRequestOrdered_it_should_return_BadRequest()
+        public async Task With_update_action_searchRequestOrdered_CreateSearchRequest_should_return_BadRequest()
         {
             SearchRequestOrdered updateSearchRequestOrdered = new SearchRequestOrdered()
             {
@@ -85,14 +85,14 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
                 RequestId = Guid.NewGuid().ToString(),
                 TimeStamp = DateTime.Now,
             };
-            var result = await _sut.CreateSearchRequest(null, updateSearchRequestOrdered);
+            var result = await _sut.CreateSearchRequest("requestId", updateSearchRequestOrdered);
 
             _agencyRequestServiceMock.Verify(x => x.ProcessSearchRequestOrdered(It.IsAny<SearchRequestOrdered>()), Times.Never);
-            Assert.IsInstanceOf(typeof(BadRequestResult), result);
+            Assert.IsInstanceOf(typeof(BadRequestObjectResult), result);
         }
 
         [Test]
-        public async Task With_exception_throws_searchRequestOrdered_it_should_return_BadRequest()
+        public async Task With_exception_throws_searchRequestOrdered_CreateSearchRequest_should_return_BadRequest()
         {
             string requestId = "exception";
             SearchRequestOrdered updateSearchRequestOrdered = new SearchRequestOrdered()
@@ -105,9 +105,138 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
             _agencyRequestServiceMock.Setup(
                 x => x.ProcessSearchRequestOrdered(It.Is<SearchRequestOrdered>(x => x.RequestId == requestId)))
             .Throws(new Exception("exception throws"));
+
             var result = await _sut.CreateSearchRequest("exceptionrequest", updateSearchRequestOrdered);
             _agencyRequestServiceMock.Verify(x => x.ProcessSearchRequestOrdered(It.IsAny<SearchRequestOrdered>()), Times.Once);
             Assert.IsInstanceOf(typeof(BadRequestResult), result);
+        }
+
+        [Test]
+        public async Task With_valid_searchRequestOrdered_CancelSearchRequest_should_return_ok_with_correct_content()
+        {
+            SearchRequestOrdered validSearchRequestOrdered = new SearchRequestOrdered()
+            {
+                Action = RequestAction.CANCEL,
+                RequestId = "121212121212",
+                SearchRequestKey = "fileId",
+                TimeStamp = DateTime.Now,
+                Person = new Person()
+                {
+                    Agency = new Agency()
+                    {
+                        RequestId = "121212121212",
+                        Code = "FMEP"
+                    }
+                }
+            };
+
+            _agencyRequestServiceMock.Setup(x => x.ProcessCancelSearchRequest(It.IsAny<SearchRequestOrdered>()))
+                .Returns(Task.FromResult<SSG_SearchRequest>(new SSG_SearchRequest()
+                {
+                    FileId = "fileId",
+                    SearchRequestId = Guid.NewGuid(),
+                    StatusCode = SearchRequestStatusCode.AgencyCancelled.Value
+                }));
+
+            var result = await _sut.CancelSearchRequest("121212121212", validSearchRequestOrdered);
+
+            _agencyRequestServiceMock.Verify(x => x.ProcessCancelSearchRequest(It.IsAny<SearchRequestOrdered>()), Times.Once);
+            var resultValue = result as OkObjectResult;
+            Assert.NotNull(resultValue);
+            var submitted = resultValue.Value as SearchRequestSubmitted;
+            Assert.NotNull(submitted);
+            Assert.AreEqual("fileId", submitted.SearchRequestKey);
+            Assert.AreEqual("FMEP", submitted.ProviderProfile.Name);
+            Assert.AreEqual("The Search Request fileId has been cancelled successfully upon the request 121212121212.", submitted.Message);
+        }
+
+        [Test]
+        public async Task With_null_key_searchRequestOrdered_CancelSearchRequest_should_return_BadRequest()
+        {
+            SearchRequestOrdered validSearchRequestOrdered = new SearchRequestOrdered()
+            {
+                Action = RequestAction.NEW,
+                RequestId = Guid.NewGuid().ToString(),
+                TimeStamp = DateTime.Now,
+            };
+            var result = await _sut.CancelSearchRequest(null, validSearchRequestOrdered);
+
+            _agencyRequestServiceMock.Verify(x => x.ProcessSearchRequestOrdered(It.IsAny<SearchRequestOrdered>()), Times.Never);
+            Assert.IsInstanceOf(typeof(BadRequestObjectResult), result);
+        }
+
+        [Test]
+        public async Task With_update_action_searchRequestOrdered_CancelSearchRequest_should_return_BadRequest()
+        {
+            SearchRequestOrdered updateSearchRequestOrdered = new SearchRequestOrdered()
+            {
+                Action = RequestAction.UPDATE,
+                RequestId = Guid.NewGuid().ToString(),
+                TimeStamp = DateTime.Now,
+            };
+            var result = await _sut.CancelSearchRequest("requestId", updateSearchRequestOrdered);
+
+            _agencyRequestServiceMock.Verify(x => x.ProcessSearchRequestOrdered(It.IsAny<SearchRequestOrdered>()), Times.Never);
+            Assert.IsInstanceOf(typeof(BadRequestObjectResult), result);
+        }
+
+        [Test]
+        public async Task With_empty_fileID_searchRequestOrdered_CancelSearchRequest_should_return_BadRequest()
+        {
+            SearchRequestOrdered updateSearchRequestOrdered = new SearchRequestOrdered()
+            {
+                Action = RequestAction.CANCEL,
+                RequestId = Guid.NewGuid().ToString(),
+                TimeStamp = DateTime.Now,
+            };
+            var result = await _sut.CancelSearchRequest("requestId", updateSearchRequestOrdered);
+
+            _agencyRequestServiceMock.Verify(x => x.ProcessSearchRequestOrdered(It.IsAny<SearchRequestOrdered>()), Times.Never);
+            Assert.IsInstanceOf(typeof(BadRequestObjectResult), result);
+        }
+
+        [Test]
+        public async Task With_nonexist_fileID_searchRequestOrdered_CancelSearchRequest_should_return_BadRequest()
+        {
+            SearchRequestOrdered updateSearchRequestOrdered = new SearchRequestOrdered()
+            {
+                Action = RequestAction.CANCEL,
+                RequestId = Guid.NewGuid().ToString(),
+                TimeStamp = DateTime.Now,
+                SearchRequestKey="notexist"
+            };
+            _agencyRequestServiceMock.Setup(x => x.ProcessCancelSearchRequest(It.IsAny<SearchRequestOrdered>()))
+                .Returns(Task.FromResult<SSG_SearchRequest>(null));
+            var result = await _sut.CancelSearchRequest("requestId", updateSearchRequestOrdered);
+
+            _agencyRequestServiceMock.Verify(x => x.ProcessSearchRequestOrdered(It.IsAny<SearchRequestOrdered>()), Times.Never);
+            Assert.IsInstanceOf(typeof(BadRequestObjectResult), result);
+        }
+
+        [Test]
+        public async Task With_exception_CancelSearchRequest_should_return_OK_with_failed_message()
+        {
+            SearchRequestOrdered updateSearchRequestOrdered = new SearchRequestOrdered()
+            {
+                Action = RequestAction.CANCEL,
+                RequestId = "23232321",
+                TimeStamp = DateTime.Now,
+                SearchRequestKey = "exceptionFileId"
+            };
+
+            _agencyRequestServiceMock.Setup(
+                x => x.ProcessCancelSearchRequest(It.Is<SearchRequestOrdered>(x => x.SearchRequestKey == "exceptionFileId")))
+                .Throws(new Exception("exception throws"));
+
+            var result = await _sut.CancelSearchRequest("requestId", updateSearchRequestOrdered);
+
+            _agencyRequestServiceMock.Verify(x => x.ProcessCancelSearchRequest(It.IsAny<SearchRequestOrdered>()), Times.Once);
+            var resultValue = result as OkObjectResult;
+            Assert.NotNull(resultValue);
+            var submitted = resultValue.Value as SearchRequestSubmitted;
+            Assert.NotNull(submitted);
+            Assert.AreEqual("exceptionFileId", submitted.SearchRequestKey);
+            Assert.AreEqual("The Search Request exceptionFileId cannot be cancelled upon the request 23232321.", submitted.Message);
         }
     }
 }

--- a/app/DynamicsAdapter/DynamicsAdapter.Web.Test/SearchAgency/AgencyRequestServiceTest.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web.Test/SearchAgency/AgencyRequestServiceTest.cs
@@ -275,7 +275,7 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
         [Test]
         public async Task normal_searchRequestOrdered_ProcessSearchRequestOrdered_should_succeed()
         {
-            bool result = await _sut.ProcessSearchRequestOrdered(_searchRequstOrdered);
+            SSG_SearchRequest ssgSearchRequest = await _sut.ProcessSearchRequestOrdered(_searchRequstOrdered);
             _searchRequestServiceMock.Verify( m=>m.CreateSearchRequest(It.IsAny<SearchRequestEntity>(), It.IsAny<CancellationToken>()),Times.Once );
             _searchRequestServiceMock.Verify(m => m.SavePerson(It.IsAny<PersonEntity>(), It.IsAny<CancellationToken>()), Times.Once);
             _searchRequestServiceMock.Verify(m => m.CreateIdentifier(It.IsAny<IdentifierEntity>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
@@ -310,7 +310,7 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
                 SearchRequestKey = "key",
                 Person = nullPerson
             };
-            bool result = await _sut.ProcessSearchRequestOrdered(searchRequstOrdered);
+            SSG_SearchRequest ssgSearchRequest = await _sut.ProcessSearchRequestOrdered(searchRequstOrdered);
             _searchRequestServiceMock.Verify(m => m.CreateSearchRequest(It.IsAny<SearchRequestEntity>(), It.IsAny<CancellationToken>()), Times.Once);
             _searchRequestServiceMock.Verify(m => m.SavePerson(It.IsAny<PersonEntity>(), It.IsAny<CancellationToken>()), Times.Once);
             _searchRequestServiceMock.Verify(m => m.CreateIdentifier(It.IsAny<IdentifierEntity>(), It.IsAny<CancellationToken>()), Times.Never);

--- a/app/DynamicsAdapter/DynamicsAdapter.Web.Test/SearchAgency/AgencyRequestServiceTest.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web.Test/SearchAgency/AgencyRequestServiceTest.cs
@@ -328,5 +328,25 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
                     .Throws(new Exception("fakeException"));
             Assert.ThrowsAsync<Exception>(async () => await _sut.ProcessSearchRequestOrdered(_searchRequstOrdered));
         }
+
+        [Test]
+        public async Task normal_searchRequestOrdered_ProcessCancelSearchRequest_should_succeed()
+        {
+            _searchRequestServiceMock.Setup(x => x.CancelSearchRequest(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult<SSG_SearchRequest>(new SSG_SearchRequest()
+                {
+                    FileId = "fileId"
+                }));
+            SSG_SearchRequest ssgSearchRequest = await _sut.ProcessCancelSearchRequest(_searchRequstOrdered);
+            _searchRequestServiceMock.Verify(m => m.CancelSearchRequest(It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [Test]
+        public void exception_searchRequestOrdered_ProcessCancelSearchRequest_should_throw_exception()
+        {
+            _searchRequestServiceMock.Setup(x => x.CancelSearchRequest(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Throws(new Exception("fakeException"));
+            Assert.ThrowsAsync<Exception>(async () => await _sut.ProcessCancelSearchRequest(_searchRequstOrdered));
+        }
     }
 }

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/AgencyRequestController.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/AgencyRequestController.cs
@@ -1,3 +1,4 @@
+using DynamicsAdapter.Web.PersonSearch.Models;
 using DynamicsAdapter.Web.SearchAgency.Models;
 using Fams3Adapter.Dynamics.SearchRequest;
 using Microsoft.AspNetCore.Http;
@@ -87,8 +88,11 @@ namespace DynamicsAdapter.Web.SearchAgency
                 SearchRequestId = createdSearchRequest.SearchRequestId,
                 TimeStamp = DateTime.Now,
                 EstimatedCompletion = DateTime.Now.AddDays(60), //todo: need to implement when design is ready.
-                QueuePosition = 4,
-                Message = $"The new Search Request reference: {requestOrdered.RequestId} has been submitted successfully."
+                QueuePosition = 4,//todo: need to implement when design is ready.
+                Message = $"The new Search Request reference: {requestOrdered.RequestId} has been submitted successfully.",
+                ProviderProfile = new ProviderProfile() {
+                    Name= requestOrdered?.Person?.Agency?.Code
+                }
             };
         }
     }

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/AgencyRequestController.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/AgencyRequestController.cs
@@ -36,8 +36,8 @@ namespace DynamicsAdapter.Web.SearchAgency
         [OpenApiTag("Agency Search Request API")]
         public async Task<IActionResult> CreateSearchRequest(string requestId, [FromBody]SearchRequestOrdered searchRequestOrdered)
         {
-            if (string.IsNullOrEmpty(requestId)) return BadRequest();
-            if (searchRequestOrdered.Action != RequestAction.NEW) return BadRequest();
+            if (string.IsNullOrEmpty(requestId)) return BadRequest(new { Message = "requestId cannot be empty." });
+            if (searchRequestOrdered.Action != RequestAction.NEW) return BadRequest(new { Message = "CreateSearchRequest should only get NEW request." });
             try
             {
                 SSG_SearchRequest createdSearchRequest = await _agencyRequestService.ProcessSearchRequestOrdered(searchRequestOrdered);
@@ -89,6 +89,8 @@ namespace DynamicsAdapter.Web.SearchAgency
             try
             {
                 cancelledSearchRequest = await _agencyRequestService.ProcessCancelSearchRequest(searchRequestOrdered);
+                if(cancelledSearchRequest == null)
+                    return BadRequest(new { Message = $"FileId ( {searchRequestOrdered.SearchRequestKey} ) is invalid." });
             }
             catch (Exception ex)
             {

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/AgencyRequestController.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/AgencyRequestController.cs
@@ -1,4 +1,5 @@
 using DynamicsAdapter.Web.SearchAgency.Models;
+using Fams3Adapter.Dynamics.SearchRequest;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -37,8 +38,9 @@ namespace DynamicsAdapter.Web.SearchAgency
             if (searchRequestOrdered.Action != RequestAction.NEW) return BadRequest();
             try
             {
-                await _agencyRequestService.ProcessSearchRequestOrdered(searchRequestOrdered);
-                return Ok();
+                SSG_SearchRequest createdSearchRequest = await _agencyRequestService.ProcessSearchRequestOrdered(searchRequestOrdered);
+                 
+                return Ok(BuildSearchRequestSubmitted(createdSearchRequest, searchRequestOrdered));
             }
             catch (Exception ex)
             {
@@ -73,6 +75,21 @@ namespace DynamicsAdapter.Web.SearchAgency
             //todo: Not implemented yet.
             await Task.Delay(1);
             return Ok();
+        }
+
+        private SearchRequestSubmitted BuildSearchRequestSubmitted(SSG_SearchRequest createdSearchRequest, SearchRequestOrdered requestOrdered)
+        {
+            return new SearchRequestSubmitted()
+            {
+                Action = requestOrdered.Action,
+                RequestId = requestOrdered.RequestId,
+                SearchRequestKey = createdSearchRequest.FileId,
+                SearchRequestId = createdSearchRequest.SearchRequestId,
+                TimeStamp = DateTime.Now,
+                EstimatedCompletion = DateTime.Now.AddDays(60), //todo: need to implement when design is ready.
+                QueuePosition = 4,
+                Message = $"The new Search Request reference: {requestOrdered.RequestId} has been submitted successfully."
+            };
         }
     }
 }

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/AgencyRequestService.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/AgencyRequestService.cs
@@ -18,7 +18,7 @@ namespace DynamicsAdapter.Web.SearchAgency
 {
     public interface IAgencyRequestService
     {
-        Task<bool> ProcessSearchRequestOrdered(SearchRequestOrdered searchRequestOrdered);
+        Task<SSG_SearchRequest> ProcessSearchRequestOrdered(SearchRequestOrdered searchRequestOrdered);
     }
 
     public class AgencyRequestService : IAgencyRequestService
@@ -41,7 +41,7 @@ namespace DynamicsAdapter.Web.SearchAgency
             _uploadedSearchRequest = null;
         }
 
-        public async Task<bool> ProcessSearchRequestOrdered(SearchRequestOrdered searchRequestOrdered)
+        public async Task<SSG_SearchRequest> ProcessSearchRequestOrdered(SearchRequestOrdered searchRequestOrdered)
         {
             _personSought = searchRequestOrdered.Person;
             var cts = new CancellationTokenSource();
@@ -61,7 +61,7 @@ namespace DynamicsAdapter.Web.SearchAgency
             await UploadPhones();
             await UploadEmployment();
             await UploadRelatedPersons();
-            return true;
+            return _uploadedSearchRequest;
         }
 
         private async Task<bool> UploadIdentifiers()

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/AgencyRequestService.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/AgencyRequestService.cs
@@ -19,6 +19,7 @@ namespace DynamicsAdapter.Web.SearchAgency
     public interface IAgencyRequestService
     {
         Task<SSG_SearchRequest> ProcessSearchRequestOrdered(SearchRequestOrdered searchRequestOrdered);
+        Task<SSG_SearchRequest> ProcessCancelSearchRequest(SearchRequestOrdered cancelSearchRequest);
     }
 
     public class AgencyRequestService : IAgencyRequestService
@@ -62,6 +63,13 @@ namespace DynamicsAdapter.Web.SearchAgency
             await UploadEmployment();
             await UploadRelatedPersons();
             return _uploadedSearchRequest;
+        }
+
+        public async Task<SSG_SearchRequest> ProcessCancelSearchRequest(SearchRequestOrdered searchRequestOrdered)
+        {
+            var cts = new CancellationTokenSource();
+            _cancellationToken = cts.Token;
+            return await _searchRequestService.CancelSearchRequest(searchRequestOrdered.SearchRequestKey, _cancellationToken);       
         }
 
         private async Task<bool> UploadIdentifiers()

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/Models/SearchRequestEvent.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/Models/SearchRequestEvent.cs
@@ -1,7 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace DynamicsAdapter.Web.SearchAgency.Models
 {
@@ -25,6 +22,7 @@ namespace DynamicsAdapter.Web.SearchAgency.Models
         ///   action requested by agency, new, update, cancel, notify"
         /// </summary>
         public RequestAction Action { get; set; }
+        public DynamicsAdapter.Web.PersonSearch.Models.ProviderProfile ProviderProfile { get; set; }
     }
 
     public enum RequestAction

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/Models/SearchRequestSubmitted.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/Models/SearchRequestSubmitted.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace DynamicsAdapter.Web.SearchAgency.Models
+{
+    public class SearchRequestSubmitted : SearchRequestEvent
+    {
+        public string Message { get; set; }
+        public int QueuePosition { get; set; }
+        public DateTime EstimatedCompletion { get; set; }
+    }
+}

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/Startup.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/Startup.cs
@@ -35,7 +35,6 @@ using Quartz.Spi;
 using Simple.OData.Client;
 using System;
 using System.Collections.Generic;
-using System.Net.Http;
 
 namespace DynamicsAdapter.Web
 {

--- a/app/DynamicsAdapter/Fams3Adapter.Dynamics/SearchRequest/SSG_SearchRequest.cs
+++ b/app/DynamicsAdapter/Fams3Adapter.Dynamics/SearchRequest/SSG_SearchRequest.cs
@@ -153,6 +153,9 @@ namespace Fams3Adapter.Dynamics.SearchRequest
 
         [JsonProperty("ssg_AgencyLocation")]
         public virtual SSG_AgencyLocation AgencyLocation { get; set; }
+
+        [JsonProperty("statuscode")]
+        public int StatusCode { get; set; }
     }
 
     public class SSG_SearchRequest : SearchRequestEntity

--- a/app/DynamicsAdapter/Fams3Adapter.Dynamics/SearchRequest/SSG_SearchRequest.cs
+++ b/app/DynamicsAdapter/Fams3Adapter.Dynamics/SearchRequest/SSG_SearchRequest.cs
@@ -154,8 +154,6 @@ namespace Fams3Adapter.Dynamics.SearchRequest
         [JsonProperty("ssg_AgencyLocation")]
         public virtual SSG_AgencyLocation AgencyLocation { get; set; }
 
-        [JsonProperty("statuscode")]
-        public int StatusCode { get; set; }
     }
 
     public class SSG_SearchRequest : SearchRequestEntity
@@ -165,6 +163,9 @@ namespace Fams3Adapter.Dynamics.SearchRequest
 
         [JsonProperty("ssg_name")]
         public string FileId { get; set; }
+
+        [JsonProperty("statuscode")]
+        public int StatusCode { get; set; }
 
         public override string ToString()
         {

--- a/app/DynamicsAdapter/Fams3Adapter.Dynamics/SearchRequest/SearchRequestService.cs
+++ b/app/DynamicsAdapter/Fams3Adapter.Dynamics/SearchRequest/SearchRequestService.cs
@@ -19,6 +19,8 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 
+using Entry = System.Collections.Generic.Dictionary<string, object>;
+
 namespace Fams3Adapter.Dynamics.SearchRequest
 {
     public interface ISearchRequestService
@@ -41,6 +43,7 @@ namespace Fams3Adapter.Dynamics.SearchRequest
         Task<SSG_InvolvedParty> CreateInvolvedParty(InvolvedPartyEntity involvedParty, CancellationToken cancellationToken);
         Task<SSG_SearchRequestResultTransaction> CreateTransaction(SSG_SearchRequestResultTransaction transaction, CancellationToken cancellationToken);
         Task<SSG_SearchRequest> CreateSearchRequest(SearchRequestEntity searchRequest, CancellationToken cancellationToken);
+        Task<SSG_SearchRequest> CancelSearchRequest(string fileId, CancellationToken cancellationToken);
     }
 
     /// <summary>
@@ -405,5 +408,13 @@ namespace Fams3Adapter.Dynamics.SearchRequest
             return await this._oDataClient.For<SSG_SearchRequest>().Set(searchRequest).InsertEntryAsync(cancellationToken);
         }
 
+        public async Task<SSG_SearchRequest> CancelSearchRequest(string fileId, CancellationToken cancellationToken)
+        {
+            return await _oDataClient
+                        .For<SSG_SearchRequest>()
+                        .Filter(x => x.FileId == fileId)
+                        .Set(new Entry { { Keys.DYNAMICS_STATUS_CODE_FIELD, SearchRequestStatusCode.AgencyCancelled.Value } })
+                        .UpdateEntryAsync(cancellationToken);
+        }
     }
 }

--- a/app/DynamicsAdapter/Fams3Adapter.Dynamics/SearchRequest/SearchRequestService.cs
+++ b/app/DynamicsAdapter/Fams3Adapter.Dynamics/SearchRequest/SearchRequestService.cs
@@ -410,9 +410,13 @@ namespace Fams3Adapter.Dynamics.SearchRequest
 
         public async Task<SSG_SearchRequest> CancelSearchRequest(string fileId, CancellationToken cancellationToken)
         {
+            SSG_SearchRequest searchRequest = await _oDataClient.For<SSG_SearchRequest>().Filter(x => x.FileId == fileId).FindEntryAsync(cancellationToken);
+
+            if (searchRequest == null) return null;
+
             return await _oDataClient
                         .For<SSG_SearchRequest>()
-                        .Filter(x => x.FileId == fileId)
+                        .Key(searchRequest.SearchRequestId)
                         .Set(new Entry { { Keys.DYNAMICS_STATUS_CODE_FIELD, SearchRequestStatusCode.AgencyCancelled.Value } })
                         .UpdateEntryAsync(cancellationToken);
         }

--- a/app/DynamicsAdapter/Fams3Adapter.Dynamics/SearchRequest/SearchRequestStatusCode.cs
+++ b/app/DynamicsAdapter/Fams3Adapter.Dynamics/SearchRequest/SearchRequestStatusCode.cs
@@ -1,0 +1,15 @@
+﻿using Fams3Adapter.Dynamics.OptionSets.Models;
+
+namespace Fams3Adapter.Dynamics.SearchRequest
+{
+    public class SearchRequestStatusCode : Enumeration
+    {
+        public static SearchRequestStatusCode AgencyCancelled =
+            new SearchRequestStatusCode(867670010, "Agency Cancelled");
+
+        protected SearchRequestStatusCode(int value, string name) : base(value, name)
+        {
+        }
+
+    }
+}

--- a/app/SearchApi/BcGov.Fams3.SearchApi.Contracts/SearchRequest/SearchRequestEvent.cs
+++ b/app/SearchApi/BcGov.Fams3.SearchApi.Contracts/SearchRequest/SearchRequestEvent.cs
@@ -9,11 +9,11 @@ namespace BcGov.Fams3.SearchApi.Contracts.SearchRequest
 
     {
         /// <summary>
-        /// This is Data Partner Id for the SearchRequest
+        /// This is the agency search request Id for the SearchRequest
         /// </summary>
         string RequestId { get; }
         /// <summary>
-        /// This is the Key to identify the searchRequest in dynamics it is made of FileId_SequenceNumber
+        /// This is the Key to identify the searchRequest in dynamics it is FileId
         /// </summary>
         string SearchRequestKey { get; }
         /// <summary>
@@ -23,7 +23,7 @@ namespace BcGov.Fams3.SearchApi.Contracts.SearchRequest
         DateTime TimeStamp { get; }
         ////
         /// <summary>
-        ///   action requested by agency, new, update, cancel, notify"
+        ///   action requested by agency, new, update, cancel, notify
         /// </summary>
         public RequestAction Action { get; set; }
 

--- a/app/SearchApi/SearchRequest.Adaptor.Test/Notifier/SearchRequestNotifierTest.cs
+++ b/app/SearchApi/SearchRequest.Adaptor.Test/Notifier/SearchRequestNotifierTest.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 using SearchRequestAdaptor.Configuration;
 using SearchRequestAdaptor.Notifier;
 using SearchRequestAdaptor.Publisher;
+using SearchRequestAdaptor.Publisher.Models;
 using System;
 using System.Collections.Generic;
 using System.Net;
@@ -92,7 +93,7 @@ namespace SearchRequest.Adaptor.Test.Notifier
 
             _searchRquestEventPublisherMock.Verify(
                 x => x.PublishSearchRequestSubmitted(
-                It.IsAny<SearchRequestEvent>(), It.IsAny<string>()), Times.Once);
+                It.IsAny<SearchRequestSubmittedEvent>()), Times.Once);
         }
 
 

--- a/app/SearchApi/SearchRequest.Adaptor.Test/Notifier/SearchRequestNotifierTest.cs
+++ b/app/SearchApi/SearchRequest.Adaptor.Test/Notifier/SearchRequestNotifierTest.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using Moq.Protected;
+using Newtonsoft.Json;
 using NUnit.Framework;
 using SearchRequestAdaptor.Configuration;
 using SearchRequestAdaptor.Notifier;
@@ -13,7 +14,6 @@ using System;
 using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -55,10 +55,18 @@ namespace SearchRequest.Adaptor.Test.Notifier
                 .ReturnsAsync(new HttpResponseMessage()
                 {
                     StatusCode = HttpStatusCode.OK,
-                    Content = new StringContent("worked!"),
+                    Content = new StringContent(JsonConvert.SerializeObject(
+                        new SearchRequestSubmittedEvent()
+                        {
+                            SearchRequestId = Guid.NewGuid(),
+                            SearchRequestKey = "fileId",
+                            RequestId = "requestId",
+                            ProviderProfile = new SearchRequest.Adaptor.Publisher.Models.ProviderProfile() { Name = "AgencyName" }
+                        })),
                 })
                 .Verifiable();
-            _httpClient= new HttpClient(_httpHandlerMock.Object);
+
+            _httpClient = new HttpClient(_httpHandlerMock.Object);
             _fakeSearchRequestOrdered = new FakeSearchRequestOrdered()
             {
                 Action = BcGov.Fams3.SearchApi.Contracts.Person.RequestAction.NEW,
@@ -142,9 +150,9 @@ namespace SearchRequest.Adaptor.Test.Notifier
                 .Verifiable();
 
             _sut = new WebHookSearchRequestNotifier(_httpClient, _searchRequestOptionsMock.Object, _loggerMock.Object, _searchRquestEventPublisherMock.Object);
-           await _sut.NotifySearchRequestEventAsync(
-                    _fakeSearchRequestOrdered.RequestId,
-                    _fakeSearchRequestOrdered, CancellationToken.None);
+            await _sut.NotifySearchRequestEventAsync(
+                     _fakeSearchRequestOrdered.RequestId,
+                     _fakeSearchRequestOrdered, CancellationToken.None);
 
             _httpHandlerMock.Protected().Verify(
                     "SendAsync",
@@ -193,7 +201,7 @@ namespace SearchRequest.Adaptor.Test.Notifier
         {
             _sut = new WebHookSearchRequestNotifier(_httpClient, _searchRequestOptionsMock.Object, _loggerMock.Object, _searchRquestEventPublisherMock.Object);
 
-            Assert.ThrowsAsync<ArgumentNullException>(() =>  _sut.NotifySearchRequestEventAsync(
+            Assert.ThrowsAsync<ArgumentNullException>(() => _sut.NotifySearchRequestEventAsync(
                 _fakeSearchRequestOrdered.RequestId,
                 null, CancellationToken.None));
 

--- a/app/SearchApi/SearchRequest.Adaptor.Test/Publisher/SearchRequestEventPublisherTest.cs
+++ b/app/SearchApi/SearchRequest.Adaptor.Test/Publisher/SearchRequestEventPublisherTest.cs
@@ -90,15 +90,16 @@ namespace SearchRequest.Adaptor.Test.Publisher
         [Test]
         public async Task PublishSearchRequestSubmitted_should_pubish_submittedEvent()
         {
-            await _sut.PublishSearchRequestSubmitted(_baseEvent, "submitted");
+            SearchRequestSubmittedEvent submittedEvent = new SearchRequestSubmittedEvent();
+            await _sut.PublishSearchRequestSubmitted(submittedEvent);
             _sendEndpointMock.Verify(x => x.Send<SearchRequestSubmitted>(It.IsAny<SearchRequestSubmittedEvent>(), It.IsAny<CancellationToken>()),
                 () => { return Times.Once(); });
         }
 
         [Test]
-        public void with_null_baseEvent_PublishSearchRequestSubmitted_should_throw_exception()
+        public void with_null_submittedEvent_PublishSearchRequestSubmitted_should_throw_exception()
         {
-            Assert.ThrowsAsync<ArgumentNullException>(() => _sut.PublishSearchRequestSubmitted(null, "submitted"));
+            Assert.ThrowsAsync<ArgumentNullException>(() => _sut.PublishSearchRequestSubmitted(null));
         }
 
         [Test]

--- a/app/SearchApi/SearchRequest.Adaptor/Notifier/SearchRequestNotifier.cs
+++ b/app/SearchApi/SearchRequest.Adaptor/Notifier/SearchRequestNotifier.cs
@@ -98,11 +98,12 @@ namespace SearchRequestAdaptor.Notifier
                     }
 
                     string responseContent = await response.Content.ReadAsStringAsync();
-                    SearchRequestSubmitted submitted = (SearchRequestSubmitted)JsonConvert.DeserializeObject(responseContent);
+                    var submitted = JsonConvert.DeserializeObject<SearchRequestSubmittedEvent>(responseContent);
                     
                     _logger.LogInformation(
                         $"The webHook {webHookName} notification has executed status {eventName} successfully for {webHook.Name} webHook.");
-                    await _searchRequestEventPublisher.PublishSearchRequestSubmitted(submitted, "Search Request has been submitted successfully.");
+                    
+                    await _searchRequestEventPublisher.PublishSearchRequestSubmitted(submitted);
                 }
                 catch (Exception exception)
                 {

--- a/app/SearchApi/SearchRequest.Adaptor/Notifier/SearchRequestNotifier.cs
+++ b/app/SearchApi/SearchRequest.Adaptor/Notifier/SearchRequestNotifier.cs
@@ -97,9 +97,12 @@ namespace SearchRequestAdaptor.Notifier
                         return;
                     }
 
+                    string responseContent = await response.Content.ReadAsStringAsync();
+                    SearchRequestSubmitted submitted = (SearchRequestSubmitted)JsonConvert.DeserializeObject(responseContent);
+                    
                     _logger.LogInformation(
                         $"The webHook {webHookName} notification has executed status {eventName} successfully for {webHook.Name} webHook.");
-                    await _searchRequestEventPublisher.PublishSearchRequestSubmitted(searchRequestOrdered, "Search Request has been submitted successfully.");
+                    await _searchRequestEventPublisher.PublishSearchRequestSubmitted(submitted, "Search Request has been submitted successfully.");
                 }
                 catch (Exception exception)
                 {

--- a/app/SearchApi/SearchRequest.Adaptor/Publisher/Models/ProviderProfile.cs
+++ b/app/SearchApi/SearchRequest.Adaptor/Publisher/Models/ProviderProfile.cs
@@ -1,0 +1,9 @@
+﻿using BcGov.Fams3.SearchApi.Contracts.PersonSearch;
+
+namespace SearchRequest.Adaptor.Publisher.Models
+{
+    public class ProviderProfile
+    {
+        public string Name { get; set; }
+    }
+}

--- a/app/SearchApi/SearchRequest.Adaptor/Publisher/Models/SearchRequestFailedEvent.cs
+++ b/app/SearchApi/SearchRequest.Adaptor/Publisher/Models/SearchRequestFailedEvent.cs
@@ -14,6 +14,7 @@ namespace SearchRequestAdaptor.Publisher.Models
             this.TimeStamp = DateTime.Now;
             this.SearchRequestKey = baseEvent.SearchRequestKey;
             this.Action = baseEvent.Action;
+            this.ProviderProfile = baseEvent.ProviderProfile;
         }
 
         public string Cause { get; set; }

--- a/app/SearchApi/SearchRequest.Adaptor/Publisher/Models/SearchRequestRejectedEvent.cs
+++ b/app/SearchApi/SearchRequest.Adaptor/Publisher/Models/SearchRequestRejectedEvent.cs
@@ -15,6 +15,7 @@ namespace SearchRequestAdaptor.Publisher.Models
             this.TimeStamp = DateTime.Now;
             this.SearchRequestKey = baseEvent.SearchRequestKey;
             this.Action = baseEvent.Action;
+            this.ProviderProfile = baseEvent.ProviderProfile;
         }
 
         public string RequestId { get; set; }

--- a/app/SearchApi/SearchRequest.Adaptor/Publisher/Models/SearchRequestSubmittedEvent.cs
+++ b/app/SearchApi/SearchRequest.Adaptor/Publisher/Models/SearchRequestSubmittedEvent.cs
@@ -1,11 +1,11 @@
-﻿using BcGov.Fams3.SearchApi.Contracts.Person;
-using BcGov.Fams3.SearchApi.Contracts.PersonSearch;
+using BcGov.Fams3.SearchApi.Contracts.Person;
 using BcGov.Fams3.SearchApi.Contracts.SearchRequest;
+using SearchRequest.Adaptor.Publisher.Models;
 using System;
 
 namespace SearchRequestAdaptor.Publisher.Models
 {
-    public class SearchRequestSubmittedEvent : SearchRequestSubmitted
+    public class SearchRequestSubmittedEvent 
     {
         public SearchRequestSubmittedEvent(SearchRequestEvent baseEvent)
         {

--- a/app/SearchApi/SearchRequest.Adaptor/Publisher/Models/SearchRequestSubmittedEvent.cs
+++ b/app/SearchApi/SearchRequest.Adaptor/Publisher/Models/SearchRequestSubmittedEvent.cs
@@ -16,6 +16,10 @@ namespace SearchRequestAdaptor.Publisher.Models
             this.Action = baseEvent.Action;
         }
 
+        public SearchRequestSubmittedEvent()
+        {           
+        }
+
         public string RequestId { get; set; }
 
         public string SearchRequestKey { get; set; }

--- a/app/SearchApi/SearchRequest.Adaptor/Publisher/SearchRequestEventPublisher.cs
+++ b/app/SearchApi/SearchRequest.Adaptor/Publisher/SearchRequestEventPublisher.cs
@@ -15,7 +15,7 @@ namespace SearchRequestAdaptor.Publisher
     public interface ISearchRequestEventPublisher
     {
         public Task PublishSearchRequestFailed(SearchRequestEvent baseEvent, string message);
-        public Task PublishSearchRequestSubmitted(SearchRequestEvent baseEvent, string message);
+        public Task PublishSearchRequestSubmitted(SearchRequestSubmitted submittedEvent);
         public Task PublishSearchRequestRejected(SearchRequestEvent baseEvent, IEnumerable<ValidationResult> reasons);
 
     }
@@ -57,16 +57,13 @@ namespace SearchRequestAdaptor.Publisher
             });
         }
 
-        public async Task PublishSearchRequestSubmitted(SearchRequestEvent baseEvent, string message)
+        public async Task PublishSearchRequestSubmitted(SearchRequestSubmitted submittedEvent)
         {
-            if (baseEvent == null) throw new ArgumentNullException(nameof(SearchRequestEvent));
+            if (submittedEvent == null) throw new ArgumentNullException(nameof(SearchRequestSubmitted));
 
             var endpoint = await _sendEndpointProvider.GetSendEndpoint(new Uri($"rabbitmq://{this._rabbitMqConfiguration.Host}:{this._rabbitMqConfiguration.Port}/SearchRequestSubmitted_queue"));
 
-            await endpoint.Send<SearchRequestSubmitted>(new SearchRequestSubmittedEvent(baseEvent)
-            {
-                Message = message
-            });
+            await endpoint.Send<SearchRequestSubmitted>(submittedEvent);
         }
     }
 }

--- a/app/SearchApi/SearchRequest.Adaptor/Publisher/SearchRequestEventPublisher.cs
+++ b/app/SearchApi/SearchRequest.Adaptor/Publisher/SearchRequestEventPublisher.cs
@@ -15,7 +15,7 @@ namespace SearchRequestAdaptor.Publisher
     public interface ISearchRequestEventPublisher
     {
         public Task PublishSearchRequestFailed(SearchRequestEvent baseEvent, string message);
-        public Task PublishSearchRequestSubmitted(SearchRequestSubmitted submittedEvent);
+        public Task PublishSearchRequestSubmitted(SearchRequestSubmittedEvent submittedEvent);
         public Task PublishSearchRequestRejected(SearchRequestEvent baseEvent, IEnumerable<ValidationResult> reasons);
 
     }
@@ -57,7 +57,7 @@ namespace SearchRequestAdaptor.Publisher
             });
         }
 
-        public async Task PublishSearchRequestSubmitted(SearchRequestSubmitted submittedEvent)
+        public async Task PublishSearchRequestSubmitted(SearchRequestSubmittedEvent submittedEvent)
         {
             if (submittedEvent == null) throw new ArgumentNullException(nameof(SearchRequestSubmitted));
 


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

-FAMS3-2461 (DynaAdapter] check if search request is not - In analysis - update SR to cancel)
-FAMS3-2504 (Dynadapter send submitted response back to request adaptor.)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Tested locally with unit tests.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
