### PR TITLE
update search request - search request entity

### DIFF
--- a/app/DynamicsAdapter/DynamicsAdapter.Web.Test/SearchAgency/AgencyRequestServiceTest.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web.Test/SearchAgency/AgencyRequestServiceTest.cs
@@ -10,6 +10,7 @@ using Fams3Adapter.Dynamics.Person;
 using Fams3Adapter.Dynamics.PhoneNumber;
 using Fams3Adapter.Dynamics.RelatedPerson;
 using Fams3Adapter.Dynamics.SearchRequest;
+using Fams3Adapter.Dynamics.Types;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NUnit.Framework;
@@ -122,6 +123,7 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
                 TimeStamp = new DateTime(2010, 1, 1),
                 SearchRequestKey = "key",
                 Person = _searchRequestPerson
+        
             };
 
 
@@ -180,7 +182,14 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
 
             _fakeSearchRequest = new SearchRequestEntity()
             {
-                AgencyCode = "FMEP"
+                AgencyCode = "FMEP",
+                RequestPriority = RequestPriorityType.Rush.Value,
+                ApplicantAddressLine1 = "new Address line 1",
+                ApplicantAddressLine2 = "",
+                PersonSoughtDateOfBirth = new DateTime(1999, 1, 1),
+                LocationRequested = true,
+                PHNRequested = true,
+                DateOfDeathRequested = false
             };
 
             _ssg_fakePerson = new PersonEntity
@@ -371,8 +380,15 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
             _searchRequestServiceMock.Setup(x => x.GetSearchRequest(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult<SSG_SearchRequest>(new SSG_SearchRequest()
                 {
-                    SearchRequestId = guid
-                }));
+                    SearchRequestId = guid,
+                    RequestPriority = RequestPriorityType.Regular.Value,
+                    ApplicantAddressLine1 = "old Address line1",
+                    ApplicantAddressLine2 = "old Address line2",
+                    PersonSoughtDateOfBirth = new DateTime(1999, 1, 1),
+                    LocationRequested = true,
+                    PHNRequested = false,
+                    DateOfDeathRequested = true
+                })) ;
 
             _searchRequestServiceMock.Setup(x => x.CreateNotes(It.IsAny<NotesEntity>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult<SSG_Notese>(new SSG_Notese()

--- a/app/DynamicsAdapter/DynamicsAdapter.Web.Test/SearchAgency/AgencyRequestServiceTest.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web.Test/SearchAgency/AgencyRequestServiceTest.cs
@@ -186,7 +186,7 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
                 RequestPriority = RequestPriorityType.Rush.Value,
                 ApplicantAddressLine1 = "new Address line 1",
                 ApplicantAddressLine2 = "",
-                PersonSoughtDateOfBirth = new DateTime(1999, 1, 1),
+                PersonSoughtDateOfBirth = new DateTime(1998, 1, 1),
                 LocationRequested = true,
                 PHNRequested = true,
                 DateOfDeathRequested = false
@@ -387,8 +387,30 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
                     PersonSoughtDateOfBirth = new DateTime(1999, 1, 1),
                     LocationRequested = true,
                     PHNRequested = false,
-                    DateOfDeathRequested = true
+                    DateOfDeathRequested = true,
+                    Notes="note1"
                 })) ;
+
+            SearchRequestEntity newSearchRequest = new SearchRequestEntity()
+            {
+                AgencyCode = "FMEP",
+                RequestPriority = RequestPriorityType.Rush.Value,
+                ApplicantAddressLine1 = "new Address line 1",
+                ApplicantAddressLine2 = "",
+                PersonSoughtDateOfBirth = new DateTime(1998, 1, 1),
+                LocationRequested = true,
+                PHNRequested = true,
+                DateOfDeathRequested = false,
+                Notes="note2"
+            };
+            _mapper.Setup(m => m.Map<SearchRequestEntity>(It.IsAny<SearchRequestOrdered>()))
+                .Returns(newSearchRequest);
+
+            _searchRequestServiceMock.Setup(x => x.UpdateSearchRequest(It.IsAny<SSG_SearchRequest>(), It.IsAny<CancellationToken>()))
+                 .Returns(Task.FromResult<SSG_SearchRequest>(new SSG_SearchRequest()
+                 {
+                     SearchRequestId = guid
+                 }));
 
             _searchRequestServiceMock.Setup(x => x.CreateNotes(It.IsAny<NotesEntity>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult<SSG_Notese>(new SSG_Notese()
@@ -396,7 +418,84 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
                     NotesId = Guid.NewGuid()
                 }));
             SSG_SearchRequest ssgSearchRequest = await _sut.ProcessUpdateSearchRequest(_searchRequstOrdered);
-            _searchRequestServiceMock.Verify(m => m.CreateNotes(It.IsAny<NotesEntity>(), It.IsAny<CancellationToken>()), Times.Once);
+            _searchRequestServiceMock.Verify(m => m.UpdateSearchRequest(It.Is<SSG_SearchRequest>(
+                m=>(m.ApplicantAddressLine1== "new Address line 1"
+                && m.ApplicantAddressLine2 == "old Address line2"
+                && m.RequestPriority == RequestPriorityType.Rush.Value
+                && m.PersonSoughtDateOfBirth == new DateTime(1998, 1, 1)
+                && m.LocationRequested
+                && m.PHNRequested
+                && m.DateOfDeathRequested
+                && m.Notes == "note1")
+                ), It.IsAny<CancellationToken>()), Times.Once);
+
+            _searchRequestServiceMock.Verify(m => m.CreateNotes(It.Is<NotesEntity>(m=>m.Description== "note2"), It.IsAny<CancellationToken>()), Times.Once);
+            Assert.AreEqual(guid, ssgSearchRequest.SearchRequestId);
+        }
+
+        [Test]
+        public async Task normal_searchRequestOrdered_with_same_notes_ProcessUpdateSearchRequest_CreateNotes_should_not_run()
+        {
+            Guid guid = Guid.NewGuid();
+            _searchRequestServiceMock.Setup(x => x.GetSearchRequest(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult<SSG_SearchRequest>(new SSG_SearchRequest()
+                {
+                    SearchRequestId = guid,                    
+                    Notes = "note1"
+                }));
+
+            SearchRequestEntity newSearchRequest = new SearchRequestEntity()
+            {
+                AgencyCode = "FMEP",                
+                Notes = "note1"
+            };
+            _mapper.Setup(m => m.Map<SearchRequestEntity>(It.IsAny<SearchRequestOrdered>()))
+                .Returns(newSearchRequest);
+
+            _searchRequestServiceMock.Setup(x => x.UpdateSearchRequest(It.IsAny<SSG_SearchRequest>(), It.IsAny<CancellationToken>()))
+                 .Returns(Task.FromResult<SSG_SearchRequest>(new SSG_SearchRequest()
+                 {
+                     SearchRequestId = guid,
+                     Notes = "note1"
+                 }));
+
+            SSG_SearchRequest ssgSearchRequest = await _sut.ProcessUpdateSearchRequest(_searchRequstOrdered);
+            _searchRequestServiceMock.Verify(m => m.UpdateSearchRequest(It.IsAny<SSG_SearchRequest>(), It.IsAny<CancellationToken>()), Times.Once);
+
+            _searchRequestServiceMock.Verify(m => m.CreateNotes(It.IsAny<NotesEntity>(), It.IsAny<CancellationToken>()), Times.Never);
+            Assert.AreEqual(guid, ssgSearchRequest.SearchRequestId);
+        }
+
+        [Test]
+        public async Task new_searchrequestOrdered_with_empty_notes_ProcessUpdateSearchRequest_CreateNotes_should_not_run()
+        {
+            Guid guid = Guid.NewGuid();
+            _searchRequestServiceMock.Setup(x => x.GetSearchRequest(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult<SSG_SearchRequest>(new SSG_SearchRequest()
+                {
+                    SearchRequestId = guid,
+                    Notes = "note1"
+                }));
+
+            SearchRequestEntity newSearchRequest = new SearchRequestEntity()
+            {
+                AgencyCode = "FMEP",
+                Notes = ""
+            };
+            _mapper.Setup(m => m.Map<SearchRequestEntity>(It.IsAny<SearchRequestOrdered>()))
+                .Returns(newSearchRequest);
+
+            _searchRequestServiceMock.Setup(x => x.UpdateSearchRequest(It.IsAny<SSG_SearchRequest>(), It.IsAny<CancellationToken>()))
+                 .Returns(Task.FromResult<SSG_SearchRequest>(new SSG_SearchRequest()
+                 {
+                     SearchRequestId = guid,
+                     Notes = "note1"
+                 }));
+
+            SSG_SearchRequest ssgSearchRequest = await _sut.ProcessUpdateSearchRequest(_searchRequstOrdered);
+            _searchRequestServiceMock.Verify(m => m.UpdateSearchRequest(It.IsAny<SSG_SearchRequest>(), It.IsAny<CancellationToken>()), Times.Once);
+
+            _searchRequestServiceMock.Verify(m => m.CreateNotes(It.IsAny<NotesEntity>(), It.IsAny<CancellationToken>()), Times.Never);
             Assert.AreEqual(guid, ssgSearchRequest.SearchRequestId);
         }
 
@@ -405,12 +504,6 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
         {
             Guid guid = Guid.NewGuid();
             _searchRequestServiceMock.Setup(x => x.GetSearchRequest(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult<SSG_SearchRequest>(new SSG_SearchRequest()
-                {
-                    SearchRequestId = guid
-                }));
-
-            _searchRequestServiceMock.Setup(x => x.CreateNotes(It.IsAny<NotesEntity>(), It.IsAny<CancellationToken>()))
                 .Throws(new Exception("fakeException"));
             Assert.ThrowsAsync<Exception>(async () => await _sut.ProcessUpdateSearchRequest(_searchRequstOrdered));
         }

--- a/app/DynamicsAdapter/Fams3Adapter.Dynamics.Test/SearchRequest/SearchRequestService_SearchRequest_Test.cs
+++ b/app/DynamicsAdapter/Fams3Adapter.Dynamics.Test/SearchRequest/SearchRequestService_SearchRequest_Test.cs
@@ -305,5 +305,100 @@ namespace Fams3Adapter.Dynamics.Test.SearchRequest
 
             Assert.ThrowsAsync<WebRequestException>(async () => await _sut.CancelSearchRequest("fileId", CancellationToken.None));
         }
+
+        [Test]
+        public async Task update_correct_SearchRequest_should_success()
+        {
+            _odataClientMock.Setup(x => x.For<SSG_Agency>(null)
+               .Filter(It.IsAny<Expression<Func<SSG_Agency, bool>>>())
+               .FindEntryAsync(It.IsAny<CancellationToken>()))
+               .Returns(Task.FromResult<SSG_Agency>(new SSG_Agency()
+               {
+                   AgencyId = Guid.NewGuid(),
+                   AgencyCode = "fmep"
+               }));
+
+            _odataClientMock.Setup(x => x.For<SSG_SearchRequestReason>(null)
+                 .Filter(It.IsAny<Expression<Func<SSG_SearchRequestReason, bool>>>())
+                 .FindEntryAsync(It.IsAny<CancellationToken>()))
+                 .Returns(Task.FromResult<SSG_SearchRequestReason>(new SSG_SearchRequestReason()
+                 {
+                     ReasonId = Guid.NewGuid(),
+                     ReasonCode = "reasonCode"
+                 }));
+
+            _odataClientMock.Setup(x => x.For<SSG_AgencyLocation>(null)
+                 .Filter(It.IsAny<Expression<Func<SSG_AgencyLocation, bool>>>())
+                 .FindEntryAsync(It.IsAny<CancellationToken>()))
+                 .Returns(Task.FromResult<SSG_AgencyLocation>(new SSG_AgencyLocation()
+                 {
+                     AgencyLocationId = Guid.NewGuid(),
+                     City = "city"
+                 }));
+
+            _odataClientMock.Setup(x => x.For<SSG_SearchRequest>(null).Key(It.Is<Guid>(m=>m==testId)).Set(It.IsAny<SSG_SearchRequest>())
+                .UpdateEntryAsync(It.IsAny<CancellationToken>()))
+                .Returns(Task.FromResult(new SSG_SearchRequest()
+                {
+                    SearchRequestId = testId
+                })
+                );
+
+            var searchRequest = new SSG_SearchRequest()
+            {
+                AgencyCode = "fmep",
+                SearchRequestId=testId
+            };
+            var result = await _sut.UpdateSearchRequest(searchRequest, CancellationToken.None);
+
+            Assert.AreEqual(testId, result.SearchRequestId);
+
+        }
+
+        [Test]
+        public void exception_UpdateSearchRequest_should_throw_exception()
+        {
+            _odataClientMock.Setup(x => x.For<SSG_Agency>(null)
+               .Filter(It.IsAny<Expression<Func<SSG_Agency, bool>>>())
+               .FindEntryAsync(It.IsAny<CancellationToken>()))
+               .Returns(Task.FromResult<SSG_Agency>(new SSG_Agency()
+               {
+                   AgencyId = Guid.NewGuid(),
+                   AgencyCode = "fmep"
+               }));
+
+            _odataClientMock.Setup(x => x.For<SSG_SearchRequestReason>(null)
+                 .Filter(It.IsAny<Expression<Func<SSG_SearchRequestReason, bool>>>())
+                 .FindEntryAsync(It.IsAny<CancellationToken>()))
+                 .Returns(Task.FromResult<SSG_SearchRequestReason>(new SSG_SearchRequestReason()
+                 {
+                     ReasonId = Guid.NewGuid(),
+                     ReasonCode = "reasonCode"
+                 }));
+
+            _odataClientMock.Setup(x => x.For<SSG_AgencyLocation>(null)
+                 .Filter(It.IsAny<Expression<Func<SSG_AgencyLocation, bool>>>())
+                 .FindEntryAsync(It.IsAny<CancellationToken>()))
+                 .Returns(Task.FromResult<SSG_AgencyLocation>(new SSG_AgencyLocation()
+                 {
+                     AgencyLocationId = Guid.NewGuid(),
+                     City = "city"
+                 }));
+
+            _odataClientMock.Setup(x => x.For<SSG_SearchRequest>(null).Key(It.Is<Guid>(m => m == testId)).Set(It.IsAny<SSG_SearchRequest>())
+                .UpdateEntryAsync(It.IsAny<CancellationToken>()))
+                .Throws(WebRequestException.CreateFromStatusCode(
+                        System.Net.HttpStatusCode.NotFound,
+                        new WebRequestExceptionMessageSource(),
+                        ""
+                        ));
+
+            var searchRequest = new SSG_SearchRequest()
+            {
+                AgencyCode = "fmep",
+                SearchRequestId = testId
+            };
+            Assert.ThrowsAsync<WebRequestException>(async () => await _sut.UpdateSearchRequest(searchRequest, CancellationToken.None));
+        }
     }
 }

--- a/app/DynamicsAdapter/Fams3Adapter.Dynamics/SearchRequest/SSG_SearchRequest.cs
+++ b/app/DynamicsAdapter/Fams3Adapter.Dynamics/SearchRequest/SSG_SearchRequest.cs
@@ -114,7 +114,7 @@ namespace Fams3Adapter.Dynamics.SearchRequest
         [JsonProperty("ssg_scheduledate")]
         public DateTime RequestDate { get; set; }
 
-        [JsonProperty(" ssg_payorid")]
+        [JsonProperty("ssg_payorid")]
         public string PayerId { get; set; }
 
         [JsonProperty("ssg_organizationcasetrackingid")]

--- a/app/DynamicsAdapter/Fams3Adapter.Dynamics/SearchRequest/SSG_SearchRequest.cs
+++ b/app/DynamicsAdapter/Fams3Adapter.Dynamics/SearchRequest/SSG_SearchRequest.cs
@@ -152,7 +152,7 @@ namespace Fams3Adapter.Dynamics.SearchRequest
         public virtual SSG_SearchRequestReason SearchReason { get; set; }
 
         [JsonProperty("ssg_agencylocationstring")]
-        public string AgencyOfficeLocationText { get; set; } //used to link ssg_searchrequestreason
+        public string AgencyOfficeLocationText { get; set; } //used to link ssg_AgencyLocation
 
         [JsonProperty("ssg_AgencyLocation")]
         public virtual SSG_AgencyLocation AgencyLocation { get; set; }

--- a/app/DynamicsAdapter/Fams3Adapter.Dynamics/SearchRequest/SearchRequestService.cs
+++ b/app/DynamicsAdapter/Fams3Adapter.Dynamics/SearchRequest/SearchRequestService.cs
@@ -14,7 +14,6 @@ using Fams3Adapter.Dynamics.Person;
 using Fams3Adapter.Dynamics.PhoneNumber;
 using Fams3Adapter.Dynamics.RelatedPerson;
 using Fams3Adapter.Dynamics.ResultTransaction;
-using Fams3Adapter.Dynamics.Types;
 using Fams3Adapter.Dynamics.Vehicle;
 using Simple.OData.Client;
 using System;
@@ -48,6 +47,7 @@ namespace Fams3Adapter.Dynamics.SearchRequest
         Task<SSG_SearchRequest> CancelSearchRequest(string fileId, CancellationToken cancellationToken);
         Task<SSG_SearchRequest> GetSearchRequest(string fileId, CancellationToken cancellationToken);
         Task<SSG_Notese> CreateNotes(NotesEntity searchRequest, CancellationToken cancellationToken);
+        Task<SSG_SearchRequest> UpdateSearchRequest(SSG_SearchRequest newSearchRequest, CancellationToken cancellationToken);
     }
 
     /// <summary>
@@ -283,7 +283,7 @@ namespace Fams3Adapter.Dynamics.SearchRequest
                                 .FindEntryAsync(cancellationToken);
                     if (await _duplicateDetectService.Same(claim.BankInformationEntity, duplicatedClaim.BankingInformation))
                     {
-                        if( await _duplicateDetectService.Same(claim.EmploymentEntity, duplicatedClaim.Employment))
+                        if (await _duplicateDetectService.Same(claim.EmploymentEntity, duplicatedClaim.Employment))
                         {
                             duplicatedClaim.IsDuplicated = true;
                             if (duplicatedClaim.Employment != null)
@@ -317,14 +317,14 @@ namespace Fams3Adapter.Dynamics.SearchRequest
             else
             {
                 SSG_Asset_BankingInformation ssg_bank = claim.BankInformationEntity == null ? null : await CreateBankInfo(claim.BankInformationEntity, cancellationToken);
-                ssg_employment = claim.EmploymentEntity == null? null : await CreateEmployment(claim.EmploymentEntity, cancellationToken);
+                ssg_employment = claim.EmploymentEntity == null ? null : await CreateEmployment(claim.EmploymentEntity, cancellationToken);
                 claim.BankingInformation = ssg_bank;
                 claim.Employment = ssg_employment;
                 SSG_Asset_WorkSafeBcClaim ssg_Claim = await this._oDataClient.For<SSG_Asset_WorkSafeBcClaim>().Set(claim).InsertEntryAsync(cancellationToken);
                 returnedClaim = ssg_Claim;
             }
 
-            if (claim.EmploymentEntity != null && claim.EmploymentEntity.EmploymentContactEntities !=null)
+            if (claim.EmploymentEntity != null && claim.EmploymentEntity.EmploymentContactEntities != null)
             {
                 foreach (EmploymentContactEntity contact in claim.EmploymentEntity.EmploymentContactEntities)
                 {
@@ -360,7 +360,7 @@ namespace Fams3Adapter.Dynamics.SearchRequest
             {
                 Guid duplicatedPhoneId = await _duplicateDetectService.Exists(phone.SSG_Asset_ICBCClaim, phone);
                 if (duplicatedPhoneId != Guid.Empty)
-                    return new SSG_SimplePhoneNumber() {  SimplePhoneNumberId = duplicatedPhoneId };
+                    return new SSG_SimplePhoneNumber() { SimplePhoneNumberId = duplicatedPhoneId };
             }
             return await this._oDataClient.For<SSG_SimplePhoneNumber>().Set(phone).InsertEntryAsync(cancellationToken);
         }
@@ -371,45 +371,15 @@ namespace Fams3Adapter.Dynamics.SearchRequest
             {
                 Guid duplicatedPartyId = await _duplicateDetectService.Exists(involvedParty.SSG_Asset_ICBCClaim, involvedParty);
                 if (duplicatedPartyId != Guid.Empty)
-                    return new SSG_InvolvedParty() {InvolvedPartyId  = duplicatedPartyId };
+                    return new SSG_InvolvedParty() { InvolvedPartyId = duplicatedPartyId };
             }
             return await this._oDataClient.For<SSG_InvolvedParty>().Set(involvedParty).InsertEntryAsync(cancellationToken);
         }
 
         public async Task<SSG_SearchRequest> CreateSearchRequest(SearchRequestEntity searchRequest, CancellationToken cancellationToken)
         {
-            //find agencyCode in ssg_agency entity
-            string code = searchRequest.AgencyCode;
-            var agency = await _oDataClient.For<SSG_Agency>()
-                                         .Filter(x => x.AgencyCode == code)
-                                         .FindEntryAsync(cancellationToken);
-            searchRequest.Agency = agency;
-
-            //find reasoncode 
-            string reasonCode = searchRequest.SearchReasonCode;
-            var reason = await _oDataClient.For<SSG_SearchRequestReason>()
-                             .Filter(x => x.ReasonCode == reasonCode)
-                             .FindEntryAsync(cancellationToken);
-            searchRequest.SearchReason = reason;
-
-            try
-            {
-                //find agencylocation
-                //todo: We just currently use City as temp solution. expecting FMEP will provide office code later
-                string officeLocationCity = searchRequest.AgencyOfficeLocationText.Split(",")[1].Trim();
-                var officeLocation = await _oDataClient.For<SSG_AgencyLocation>()
-                     .Filter(x => x.City==officeLocationCity)
-                     .FindEntryAsync(cancellationToken);
-                if (officeLocation != null)
-                {
-                    searchRequest.AgencyLocation = officeLocation;
-                    searchRequest.AgencyOfficeLocationText = null;
-                }
-            }catch(Exception)
-            {               
-            }
-
-            return await this._oDataClient.For<SSG_SearchRequest>().Set(searchRequest).InsertEntryAsync(cancellationToken);
+            SearchRequestEntity linkedSearchRequest = await LinkSearchRequestRef(searchRequest, cancellationToken);
+            return await this._oDataClient.For<SSG_SearchRequest>().Set(linkedSearchRequest).InsertEntryAsync(cancellationToken);
         }
 
         public async Task<SSG_SearchRequest> CancelSearchRequest(string fileId, CancellationToken cancellationToken)
@@ -432,9 +402,51 @@ namespace Fams3Adapter.Dynamics.SearchRequest
             return ssgSearchRequest;
         }
 
+        public async Task<SSG_SearchRequest> UpdateSearchRequest(SSG_SearchRequest newSearchRequest, CancellationToken cancellationToken)
+        {
+            SSG_SearchRequest linkedSearchRequest = (SSG_SearchRequest)await LinkSearchRequestRef(newSearchRequest, cancellationToken);
+            return await this._oDataClient.For<SSG_SearchRequest>().Set(linkedSearchRequest).UpdateEntryAsync(cancellationToken);
+        }
+
         public async Task<SSG_Notese> CreateNotes(NotesEntity note, CancellationToken cancellationToken)
         {
             return await this._oDataClient.For<SSG_Notese>().Set(note).InsertEntryAsync(cancellationToken);
+        }
+
+        private async Task<SearchRequestEntity> LinkSearchRequestRef(SearchRequestEntity searchRequest, CancellationToken cancellationToken)
+        {
+            //find agencyCode in ssg_agency entity
+            string code = searchRequest.AgencyCode;
+            var agency = await _oDataClient.For<SSG_Agency>()
+                                         .Filter(x => x.AgencyCode == code)
+                                         .FindEntryAsync(cancellationToken);
+            searchRequest.Agency = agency;
+
+            //find reasoncode 
+            string reasonCode = searchRequest.SearchReasonCode;
+            var reason = await _oDataClient.For<SSG_SearchRequestReason>()
+                             .Filter(x => x.ReasonCode == reasonCode)
+                             .FindEntryAsync(cancellationToken);
+            searchRequest.SearchReason = reason;
+
+            try
+            {
+                //find agencylocation
+                //todo: We just currently use City as temp solution. expecting FMEP will provide office code later
+                string officeLocationCity = searchRequest.AgencyOfficeLocationText.Split(",")[1].Trim();
+                var officeLocation = await _oDataClient.For<SSG_AgencyLocation>()
+                     .Filter(x => x.City == officeLocationCity)
+                     .FindEntryAsync(cancellationToken);
+                if (officeLocation != null)
+                {
+                    searchRequest.AgencyLocation = officeLocation;
+                    searchRequest.AgencyOfficeLocationText = null;
+                }
+            }
+            catch (Exception)
+            {
+            }
+            return searchRequest;
         }
     }
 }

--- a/app/DynamicsAdapter/Fams3Adapter.Dynamics/SearchRequest/SearchRequestService.cs
+++ b/app/DynamicsAdapter/Fams3Adapter.Dynamics/SearchRequest/SearchRequestService.cs
@@ -405,7 +405,7 @@ namespace Fams3Adapter.Dynamics.SearchRequest
         public async Task<SSG_SearchRequest> UpdateSearchRequest(SSG_SearchRequest newSearchRequest, CancellationToken cancellationToken)
         {
             SSG_SearchRequest linkedSearchRequest = (SSG_SearchRequest)await LinkSearchRequestRef(newSearchRequest, cancellationToken);
-            return await this._oDataClient.For<SSG_SearchRequest>().Set(linkedSearchRequest).UpdateEntryAsync(cancellationToken);
+            return await this._oDataClient.For<SSG_SearchRequest>().Key(linkedSearchRequest.SearchRequestId).Set(linkedSearchRequest).UpdateEntryAsync(cancellationToken);
         }
 
         public async Task<SSG_Notese> CreateNotes(NotesEntity note, CancellationToken cancellationToken)


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- FAMS3-2548(for searchRequest, if "update" provided information is different, do update the entity.)
- FAMS3-2550(for notes, if it is different than original one, add notes to notes Entity.)
- FAMS-2551(for informationRequested, if it is different than original ones, add the new ones.)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Tested Locally and added new unit tests

## Checklist:

- [X] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
