### PR TITLE
add createdByAgency flag for related entities

### DIFF
--- a/app/DynamicsAdapter/DynamicsAdapter.Web.Test/SearchAgency/AgencyRequestService_Create_Cancel_Test.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web.Test/SearchAgency/AgencyRequestService_Create_Cancel_Test.cs
@@ -91,7 +91,13 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
                 {
                     new Name()
                     {
-                        FirstName = "firstName"
+                        FirstName = "firstName",
+                        Owner=OwnerType.PersonSought
+                    },
+                    new Name()
+                    {
+                        FirstName = "applicantFirstName",
+                        Owner=OwnerType.Applicant
                     }
                 },
                 RelatedPersons = new List<RelatedPerson>()
@@ -294,6 +300,7 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
             _searchRequestServiceMock.Verify(m => m.CreateEmployment(It.IsAny<EmploymentEntity>(), It.IsAny<CancellationToken>()), Times.Once);
             _searchRequestServiceMock.Verify(m => m.CreateEmploymentContact(It.IsAny<EmploymentContactEntity>(), It.IsAny<CancellationToken>()), Times.Once);
             _searchRequestServiceMock.Verify(m => m.CreateRelatedPerson(It.IsAny<RelatedPersonEntity>(), It.IsAny<CancellationToken>()), Times.Once);
+            _searchRequestServiceMock.Verify(m => m.CreateName(It.IsAny<AliasEntity>(), It.IsAny<CancellationToken>()), Times.Once);
         }
 
         [Test]
@@ -329,6 +336,7 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
             _searchRequestServiceMock.Verify(m => m.CreateEmployment(It.IsAny<EmploymentEntity>(), It.IsAny<CancellationToken>()), Times.Never);
             _searchRequestServiceMock.Verify(m => m.CreateEmploymentContact(It.IsAny<EmploymentContactEntity>(), It.IsAny<CancellationToken>()), Times.Never);
             _searchRequestServiceMock.Verify(m => m.CreateRelatedPerson(It.IsAny<RelatedPersonEntity>(), It.IsAny<CancellationToken>()), Times.Never);
+            _searchRequestServiceMock.Verify(m => m.CreateName(It.IsAny<AliasEntity>(), It.IsAny<CancellationToken>()), Times.Never);
         }
 
         [Test]

--- a/app/DynamicsAdapter/DynamicsAdapter.Web.Test/SearchAgency/AgencyRequestService_Update_Test.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web.Test/SearchAgency/AgencyRequestService_Update_Test.cs
@@ -30,19 +30,6 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
         private Guid _validRequestGuid;
         private Guid _personGuid;
 
-        private SearchRequestOrdered _searchRequstOrdered;
-  
-        private IdentifierEntity _fakePersoneIdentifier;
-        private AddressEntity _fakePersonAddress;
-        private PhoneNumberEntity _fakePersonPhoneNumber;
-        private AliasEntity _fakeName;
-        private RelatedPersonEntity _fakeRelatedPerson;
-        private EmploymentEntity _fakeEmployment;
-        private EmploymentContactEntity _fakeEmploymentContact;
-        private PersonEntity _ssg_fakePerson;
-        private SearchRequestEntity _fakeSearchRequest;
-        private Person _searchRequestPerson;
-
         [SetUp]
         public void Init()
         {
@@ -206,7 +193,7 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
             _mapper.Setup(m => m.Map<PersonEntity>(It.IsAny<Person>()))
                .Returns(new PersonEntity() { FirstName = "changedfirstName", LastName = "lastName" });
 
-            _searchRequstOrdered = new SearchRequestOrdered()
+            SearchRequestOrdered searchRequstOrdered = new SearchRequestOrdered()
             {
                 Action = RequestAction.UPDATE,
                 RequestId = "1111111",
@@ -218,7 +205,7 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
 
                 }
             };
-            SSG_SearchRequest ssgSearchRequest = await _sut.ProcessUpdateSearchRequest(_searchRequstOrdered);
+            SSG_SearchRequest ssgSearchRequest = await _sut.ProcessUpdateSearchRequest(searchRequstOrdered);
             _searchRequestServiceMock.Verify(m => m.UpdateSearchRequest(It.Is<SSG_SearchRequest>(
                 m => m.PersonSoughtFirstName == "changedfirstName"
                 && m.PersonSoughtLastName == "lastName"),
@@ -259,7 +246,7 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
             _mapper.Setup(m => m.Map<PersonEntity>(It.IsAny<Person>()))
                .Returns(new PersonEntity() { FirstName = "firstName", LastName = "lastName" });
 
-            _searchRequstOrdered = new SearchRequestOrdered()
+            SearchRequestOrdered searchRequstOrdered = new SearchRequestOrdered()
             {
                 Action = RequestAction.UPDATE,
                 RequestId = "1111111",
@@ -271,7 +258,7 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
 
                 }
             };
-            SSG_SearchRequest ssgSearchRequest = await _sut.ProcessUpdateSearchRequest(_searchRequstOrdered);
+            SSG_SearchRequest ssgSearchRequest = await _sut.ProcessUpdateSearchRequest(searchRequstOrdered);
             _searchRequestServiceMock.Verify(m => m.UpdateSearchRequest(It.IsAny<SSG_SearchRequest>(),
                  It.IsAny<CancellationToken>()), Times.Never);
             _searchRequestServiceMock.Verify(m => m.UpdatePerson(It.IsAny<SSG_Person>()
@@ -283,7 +270,7 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
         }
 
         [Test]
-        public async Task RelatedPerson_changed_ProcessUpdateSearchRequest_should_run_updateRelatedPerson_correctly()
+        public async Task RelatedPerson_changed_ProcessUpdateSearchRequest_should_run_createRelatedPerson_correctly()
         {
             _searchRequestServiceMock.Setup(x => x.GetPerson(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult<SSG_Person>(new SSG_Person()
@@ -323,7 +310,7 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
                        PersonType = RelatedPersonPersonType.Relation.Value
                    });
 
-            _searchRequstOrdered = new SearchRequestOrdered()
+            SearchRequestOrdered searchRequstOrdered = new SearchRequestOrdered()
             {
                 Action = RequestAction.UPDATE,
                 RequestId = "1111111",
@@ -336,14 +323,14 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
                         new RelatedPerson(){FirstName="newFirstName", LastName="lastName"}}
                 }
             };
-            SSG_SearchRequest ssgSearchRequest = await _sut.ProcessUpdateSearchRequest(_searchRequstOrdered);
+            SSG_SearchRequest ssgSearchRequest = await _sut.ProcessUpdateSearchRequest(searchRequstOrdered);
             _searchRequestServiceMock.Verify(m => m.UpdateSearchRequest(It.IsAny<SSG_SearchRequest>(),
                  It.IsAny<CancellationToken>()), Times.Never);
             _searchRequestServiceMock.Verify(m => m.UpdatePerson(It.IsAny<SSG_Person>()
                         , It.IsAny<CancellationToken>()), Times.Never);
             _searchRequestServiceMock.Verify(m => m.CreateNotes(It.IsAny<NotesEntity>()
                 , It.IsAny<CancellationToken>()), Times.Never);
-            _searchRequestServiceMock.Verify(m => m.UpdateRelatedPerson(It.IsAny<SSG_Identity>()
+            _searchRequestServiceMock.Verify(m => m.CreateRelatedPerson(It.IsAny<RelatedPersonEntity>()
             , It.IsAny<CancellationToken>()), Times.Once);
 
             Assert.AreEqual(_validRequestGuid, ssgSearchRequest.SearchRequestId);
@@ -391,7 +378,7 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
                     PersonType = RelatedPersonPersonType.Relation.Value
                 });
 
-            _searchRequstOrdered = new SearchRequestOrdered()
+            SearchRequestOrdered searchRequstOrdered = new SearchRequestOrdered()
             {
                 Action = RequestAction.UPDATE,
                 RequestId = "1111111",
@@ -404,7 +391,7 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
                         new RelatedPerson(){FirstName="newFirstName", LastName="lastName"}}
                 }
             };
-            SSG_SearchRequest ssgSearchRequest = await _sut.ProcessUpdateSearchRequest(_searchRequstOrdered);
+            SSG_SearchRequest ssgSearchRequest = await _sut.ProcessUpdateSearchRequest(searchRequstOrdered);
             _searchRequestServiceMock.Verify(m => m.UpdateSearchRequest(It.IsAny<SSG_SearchRequest>(),
                  It.IsAny<CancellationToken>()), Times.Never);
             _searchRequestServiceMock.Verify(m => m.UpdatePerson(It.IsAny<SSG_Person>()
@@ -634,7 +621,7 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
             _mapper.Setup(m => m.Map<PersonEntity>(It.IsAny<Person>()))
                .Returns(new PersonEntity() { FirstName = "firstName", LastName = "lastName" });
 
-            _searchRequstOrdered = new SearchRequestOrdered()
+            SearchRequestOrdered searchRequstOrdered = new SearchRequestOrdered()
             {
                 Action = RequestAction.UPDATE,
                 RequestId = "1111111",
@@ -656,7 +643,7 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
                     }
                 }
             };
-            SSG_SearchRequest ssgSearchRequest = await _sut.ProcessUpdateSearchRequest(_searchRequstOrdered);
+            SSG_SearchRequest ssgSearchRequest = await _sut.ProcessUpdateSearchRequest(searchRequstOrdered);
             _searchRequestServiceMock.Verify(m => m.UpdateSearchRequest(It.IsAny<SSG_SearchRequest>(),
                  It.IsAny<CancellationToken>()), Times.Never);
             _searchRequestServiceMock.Verify(m => m.UpdatePerson(It.IsAny<SSG_Person>()
@@ -766,7 +753,7 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
             _mapper.Setup(m => m.Map<PersonEntity>(It.IsAny<Person>()))
                .Returns(new PersonEntity() { FirstName = "firstName", LastName = "lastName" });
 
-            _searchRequstOrdered = new SearchRequestOrdered()
+            SearchRequestOrdered searchRequstOrdered = new SearchRequestOrdered()
             {
                 Action = RequestAction.UPDATE,
                 RequestId = "1111111",
@@ -784,7 +771,7 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
                     }
                 }
             };
-            SSG_SearchRequest ssgSearchRequest = await _sut.ProcessUpdateSearchRequest(_searchRequstOrdered);
+            SSG_SearchRequest ssgSearchRequest = await _sut.ProcessUpdateSearchRequest(searchRequstOrdered);
             _searchRequestServiceMock.Verify(m => m.UpdateSearchRequest(It.IsAny<SSG_SearchRequest>(),
                  It.IsAny<CancellationToken>()), Times.Never);
             _searchRequestServiceMock.Verify(m => m.UpdatePerson(It.IsAny<SSG_Person>()
@@ -838,7 +825,7 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
             _mapper.Setup(m => m.Map<PersonEntity>(It.IsAny<Person>()))
                .Returns(new PersonEntity() { FirstName = "firstName", LastName = "lastName" });
 
-            _searchRequstOrdered = new SearchRequestOrdered()
+            SearchRequestOrdered searchRequstOrdered = new SearchRequestOrdered()
             {
                 Action = RequestAction.UPDATE,
                 RequestId = "1111111",
@@ -857,7 +844,7 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
                     }
                 }
             };
-            SSG_SearchRequest ssgSearchRequest = await _sut.ProcessUpdateSearchRequest(_searchRequstOrdered);
+            SSG_SearchRequest ssgSearchRequest = await _sut.ProcessUpdateSearchRequest(searchRequstOrdered);
             _searchRequestServiceMock.Verify(m => m.UpdateSearchRequest(It.IsAny<SSG_SearchRequest>(),
                  It.IsAny<CancellationToken>()), Times.Never);
             _searchRequestServiceMock.Verify(m => m.UpdatePerson(It.IsAny<SSG_Person>()
@@ -908,7 +895,7 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
             _mapper.Setup(m => m.Map<PersonEntity>(It.IsAny<Person>()))
                .Returns(new PersonEntity() { FirstName = "firstName", LastName = "lastName" });
 
-            _searchRequstOrdered = new SearchRequestOrdered()
+            SearchRequestOrdered searchRequstOrdered = new SearchRequestOrdered()
             {
                 Action = RequestAction.UPDATE,
                 RequestId = "1111111",
@@ -927,7 +914,7 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
                     }
                 }
             };
-            SSG_SearchRequest ssgSearchRequest = await _sut.ProcessUpdateSearchRequest(_searchRequstOrdered);
+            SSG_SearchRequest ssgSearchRequest = await _sut.ProcessUpdateSearchRequest(searchRequstOrdered);
             _searchRequestServiceMock.Verify(m => m.UpdateSearchRequest(It.IsAny<SSG_SearchRequest>(),
                  It.IsAny<CancellationToken>()), Times.Never);
             _searchRequestServiceMock.Verify(m => m.UpdatePerson(It.IsAny<SSG_Person>()
@@ -952,7 +939,8 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
             Guid guid = Guid.NewGuid();
             _searchRequestServiceMock.Setup(x => x.GetSearchRequest(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .Throws(new Exception("fakeException"));
-            Assert.ThrowsAsync<Exception>(async () => await _sut.ProcessUpdateSearchRequest(_searchRequstOrdered));
+            SearchRequestOrdered searchRequestOrdered = new SearchRequestOrdered();
+            Assert.ThrowsAsync<Exception>(async () => await _sut.ProcessUpdateSearchRequest(searchRequestOrdered));
         }
 
         [Test]
@@ -961,8 +949,8 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
             Guid guid = Guid.NewGuid();
             _searchRequestServiceMock.Setup(x => x.GetSearchRequest(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult<SSG_SearchRequest>(null));
-
-            SSG_SearchRequest ssgSearchRequest = await _sut.ProcessUpdateSearchRequest(_searchRequstOrdered);
+            SearchRequestOrdered searchRequestOrdered = new SearchRequestOrdered();
+            SSG_SearchRequest ssgSearchRequest = await _sut.ProcessUpdateSearchRequest(searchRequestOrdered);
             _searchRequestServiceMock.Verify(m => m.CreateNotes(It.IsAny<NotesEntity>(), It.IsAny<CancellationToken>()), Times.Never);
             Assert.AreEqual(null, ssgSearchRequest);
         }

--- a/app/DynamicsAdapter/DynamicsAdapter.Web.Test/SearchAgency/AgencyRequestService_Update_Test.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web.Test/SearchAgency/AgencyRequestService_Update_Test.cs
@@ -27,9 +27,11 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
         private Mock<ILogger<AgencyRequestService>> _loggerMock;
         private Mock<ISearchRequestService> _searchRequestServiceMock;
         private Mock<IMapper> _mapper;
+        private Guid _validRequestGuid;
+        private Guid _personGuid;
 
         private SearchRequestOrdered _searchRequstOrdered;
-        private Guid _validRequestId;
+  
         private IdentifierEntity _fakePersoneIdentifier;
         private AddressEntity _fakePersonAddress;
         private PhoneNumberEntity _fakePersonPhoneNumber;
@@ -44,229 +46,29 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
         [SetUp]
         public void Init()
         {
-            _validRequestId = Guid.NewGuid();
+            _validRequestGuid = Guid.NewGuid();
+            _personGuid = Guid.NewGuid();
             _loggerMock = new Mock<ILogger<AgencyRequestService>>();
             _searchRequestServiceMock = new Mock<ISearchRequestService>();
             _mapper = new Mock<IMapper>();
 
-            _searchRequestPerson = new Person()
-            {
-                DateOfBirth = DateTime.Now,
-                FirstName = "TEST1",
-                LastName = "TEST2",
-                Identifiers = new List<PersonalIdentifier>()
-                {
-                    new PersonalIdentifier()
-                    {
-                        Value = "test",
-                        Type = PersonalIdentifierType.BCDriverLicense,
-                        Owner = OwnerType.PersonSought
-                    },
-                    new PersonalIdentifier()
-                    {
-                        Value = "test2",
-                        Type = PersonalIdentifierType.SocialInsuranceNumber,
-                        Owner = OwnerType.PersonSought
-                    }
-                },
-                Addresses = new List<Address>()
-                {
-                    new Address()
-                    {
-                        AddressLine1 = "AddressLine1",
-                        AddressLine2 = "AddressLine2",
-                        City = "testCity",
-                        Owner=OwnerType.PersonSought
-                    }
-                },
-                Phones = new List<Phone>()
-                {
-                    new Phone()
-                    {
-                        PhoneNumber = "4005678900"
-                    }
-                },
-                Names = new List<Name>()
-                {
-                    new Name()
-                    {
-                        FirstName = "firstName"
-                    }
-                },
-                RelatedPersons = new List<RelatedPerson>()
-                {
-                    new RelatedPerson() { FirstName = "firstName" }
-                },
-
-                Employments = new List<Employment>()
-                {
-                    new Employment()
-                    {
-                        Occupation = "Occupation",
-                        Employer = new Employer()
-                        {
-                            Phones = new List<Phone>() {
-                                new Phone() { PhoneNumber = "1111111", Type = "Phone" }
-                            }
-                        }
-                    }
-                }
-
-            };
-
-            _searchRequstOrdered = new SearchRequestOrdered()
-            {
-                Action = RequestAction.NEW,
-                RequestId = "1111111",
-                SearchRequestId = Guid.NewGuid(),
-                TimeStamp = new DateTime(2010, 1, 1),
-                SearchRequestKey = "key",
-                Person = _searchRequestPerson
-
-            };
-
-
-            _fakePersoneIdentifier = new IdentifierEntity
-            {
-                Identification = "1234567",
-                SearchRequest = new SSG_SearchRequest
-                {
-                    SearchRequestId = _validRequestId
-                }
-            };
-            _fakePersonAddress = new AddressEntity
-            {
-                SearchRequest = new SSG_SearchRequest
-                {
-                    SearchRequestId = _validRequestId
-                },
-                AddressLine1 = "addressLine1"
-            };
-            _fakeEmployment = new EmploymentEntity
-            {
-                SearchRequest = new SSG_SearchRequest
-                {
-                    SearchRequestId = _validRequestId
-                }
-            };
-
-            _fakeEmploymentContact = new EmploymentContactEntity
-            {
-                PhoneNumber = "11111111"
-            };
-
-            _fakePersonPhoneNumber = new PhoneNumberEntity
-            {
-                SearchRequest = new SSG_SearchRequest
-                {
-                    SearchRequestId = _validRequestId
-                }
-            };
-
-            _fakeRelatedPerson = new RelatedPersonEntity
-            {
-                SearchRequest = new SSG_SearchRequest
-                {
-                    SearchRequestId = _validRequestId
-                },
-                LastName = "relatedChild",
-                PersonType = RelatedPersonPersonType.Relation.Value
-            };
-
-            _fakeName = new AliasEntity
-            {
-                SearchRequest = new SSG_SearchRequest
-                {
-                    SearchRequestId = _validRequestId
-                }
-            };
-
-            _fakeSearchRequest = new SearchRequestEntity()
-            {
-                AgencyCode = "FMEP",
-                RequestPriority = RequestPriorityType.Rush.Value,
-                ApplicantAddressLine1 = "new Address line 1",
-                ApplicantAddressLine2 = "",
-                PersonSoughtDateOfBirth = new DateTime(1998, 1, 1),
-                LocationRequested = true,
-                PHNRequested = true,
-                DateOfDeathRequested = false
-            };
-
-            _ssg_fakePerson = new PersonEntity
-            {
-                FirstName = "firstName",
-                LastName = "lastName"
-            };
-
-            _mapper.Setup(m => m.Map<PersonEntity>(It.IsAny<Person>()))
-               .Returns(_ssg_fakePerson);
-
-            _mapper.Setup(m => m.Map<EmploymentEntity>(It.IsAny<Employment>()))
-              .Returns(_fakeEmployment);
-
-            _mapper.Setup(m => m.Map<EmploymentContactEntity>(It.IsAny<Phone>()))
-                .Returns(_fakeEmploymentContact);
-
-            _mapper.Setup(m => m.Map<RelatedPersonEntity>(It.IsAny<RelatedPerson>()))
-                   .Returns(_fakeRelatedPerson);
-
-            _mapper.Setup(m => m.Map<SearchRequestEntity>(It.IsAny<SearchRequestOrdered>()))
-                    .Returns(_fakeSearchRequest);
-
-            _searchRequestServiceMock.Setup(x => x.CreateSearchRequest(It.Is<SearchRequestEntity>(x => x.AgencyCode == "FMEP"), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult<SSG_SearchRequest>(new SSG_SearchRequest()
-                {
-                    SearchRequestId = _validRequestId,
-                    AgencyCode = "SUCCEED"
-                }));
-
-            _searchRequestServiceMock.Setup(x => x.CreateIdentifier(It.IsAny<IdentifierEntity>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult<SSG_Identifier>(new SSG_Identifier()
-                {
-                }));
-
-            _searchRequestServiceMock.Setup(x => x.CreateAddress(It.Is<AddressEntity>(x => x.SearchRequest.SearchRequestId == _validRequestId), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult<SSG_Address>(new SSG_Address()
-                {
-                    AddressLine1 = "test full line"
-                }));
-
-            _searchRequestServiceMock.Setup(x => x.CreatePhoneNumber(It.Is<PhoneNumberEntity>(x => x.SearchRequest.SearchRequestId == _validRequestId), It.IsAny<CancellationToken>()))
-              .Returns(Task.FromResult<SSG_PhoneNumber>(new SSG_PhoneNumber()
+            _searchRequestServiceMock.Setup(x => x.GetSearchRequest(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+              .Returns(Task.FromResult<SSG_SearchRequest>(new SSG_SearchRequest()
               {
-                  TelePhoneNumber = "4007678231"
-              }));
-
-            _searchRequestServiceMock.Setup(x => x.CreateName(It.Is<AliasEntity>(x => x.SearchRequest.SearchRequestId == _validRequestId), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult<SSG_Aliase>(new SSG_Aliase()
-                {
-                    FirstName = "firstName"
-                }));
-
-            _searchRequestServiceMock.Setup(x => x.SavePerson(It.Is<PersonEntity>(x => x.SearchRequest.SearchRequestId == _validRequestId), It.IsAny<CancellationToken>()))
-            .Returns(Task.FromResult<SSG_Person>(new SSG_Person()
-            {
-                FirstName = "First"
-            }));
-
-            _searchRequestServiceMock.Setup(x => x.CreateEmployment(It.Is<EmploymentEntity>(x => x.SearchRequest.SearchRequestId == _validRequestId), It.IsAny<CancellationToken>()))
-            .Returns(Task.FromResult<SSG_Employment>(new SSG_Employment()
-            {
-                EmploymentId = Guid.NewGuid(),
-                Occupation = "Occupation"
-            }));
-
-            _searchRequestServiceMock.Setup(x => x.CreateEmploymentContact(It.IsAny<EmploymentContactEntity>(), It.IsAny<CancellationToken>()))
-            .Returns(Task.FromResult<SSG_EmploymentContact>(new SSG_EmploymentContact()
-            {
-                PhoneNumber = "4007678231"
-            }));
-
-            _searchRequestServiceMock.Setup(x => x.CreateRelatedPerson(It.Is<RelatedPersonEntity>(x => x.SearchRequest.SearchRequestId == _validRequestId), It.IsAny<CancellationToken>()))
-              .Returns(Task.FromResult<SSG_Identity>(new SSG_Identity()
-              {
-                  FirstName = "firstName"
+                  SearchRequestId = _validRequestGuid,
+                  PersonSoughtFirstName = "firstName",
+                  PersonSoughtLastName = "lastName",
+                  SSG_Persons = new List<SSG_Person>()
+                  {
+                                new SSG_Person()
+                                {
+                                    PersonId=_personGuid,
+                                    FirstName = "firstName",
+                                    LastName="lastName",
+                                    InformationSource= InformationSourceType.Request.Value,
+                                    IsCreatedByAgency=true
+                                }
+                  }.ToArray()
               }));
 
             _sut = new AgencyRequestService(_searchRequestServiceMock.Object, _loggerMock.Object, _mapper.Object);
@@ -297,7 +99,11 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
                     {
                         new SSG_Person()
                         {
-                            PersonId=personGuid, FirstName = "firstName", LastName="lastName", InformationSource= InformationSourceType.Request.Value
+                            PersonId=personGuid, 
+                            FirstName = "firstName", 
+                            LastName="lastName", 
+                            InformationSource= InformationSourceType.Request.Value,
+                            IsCreatedByAgency=true
                         }
                     }.ToArray()
                 }));
@@ -333,7 +139,7 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
             _mapper.Setup(m => m.Map<PersonEntity>(It.IsAny<Person>()))
                .Returns(new PersonEntity() { FirstName = "firstName", LastName = "lastName" });
 
-            _searchRequstOrdered = new SearchRequestOrdered()
+            SearchRequestOrdered searchRequstOrdered = new SearchRequestOrdered()
             {
                 Action = RequestAction.UPDATE,
                 RequestId = "1111111",
@@ -345,7 +151,7 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
 
                 }
             };
-            SSG_SearchRequest ssgSearchRequest = await _sut.ProcessUpdateSearchRequest(_searchRequstOrdered);
+            SSG_SearchRequest ssgSearchRequest = await _sut.ProcessUpdateSearchRequest(searchRequstOrdered);
             _searchRequestServiceMock.Verify(m => m.UpdateSearchRequest(It.Is<SSG_SearchRequest>(
                 m => (m.ApplicantAddressLine1 == "new Address line 1"
                 && m.ApplicantAddressLine2 == "old Address line2"
@@ -367,28 +173,10 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
         [Test]
         public async Task personSought_changed_ProcessUpdateSearchRequest_should_run_updateSearchRequest_updatePerson_correctly()
         {
-            Guid guid = Guid.NewGuid();
-            Guid personGuid = Guid.NewGuid();
-            _searchRequestServiceMock.Setup(x => x.GetSearchRequest(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult<SSG_SearchRequest>(new SSG_SearchRequest()
-                {
-                    SearchRequestId = guid,
-                    PersonSoughtDateOfBirth = new DateTime(1999, 1, 1),
-                    PersonSoughtFirstName = "firstName",
-                    PersonSoughtLastName = "lastName",
-                    SSG_Persons = new List<SSG_Person>()
-                    {
-                        new SSG_Person()
-                        {
-                            PersonId=personGuid, FirstName = "firstName", LastName="lastName", InformationSource= InformationSourceType.Request.Value
-                        }
-                    }.ToArray()
-                }));
-
             _searchRequestServiceMock.Setup(x => x.GetPerson(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult<SSG_Person>(new SSG_Person()
                 {
-                    PersonId = personGuid,
+                    PersonId = _personGuid,
                     LastName = "lastName",
                     FirstName = "firstName"
                 }));
@@ -406,13 +194,13 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
             _searchRequestServiceMock.Setup(x => x.UpdateSearchRequest(It.IsAny<SSG_SearchRequest>(), It.IsAny<CancellationToken>()))
                  .Returns(Task.FromResult<SSG_SearchRequest>(new SSG_SearchRequest()
                  {
-                     SearchRequestId = guid
+                     SearchRequestId = _validRequestGuid
                  }));
 
             _searchRequestServiceMock.Setup(x => x.UpdatePerson(It.IsAny<SSG_Person>(), It.IsAny<CancellationToken>()))
                  .Returns(Task.FromResult<SSG_Person>(new SSG_Person()
                  {
-                     PersonId = personGuid
+                     PersonId = _personGuid
                  }));
 
             _mapper.Setup(m => m.Map<PersonEntity>(It.IsAny<Person>()))
@@ -440,36 +228,17 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
             _searchRequestServiceMock.Verify(m => m.CreateNotes(It.IsAny<SSG_Notese>()
                 , It.IsAny<CancellationToken>()), Times.Never);
 
-            Assert.AreEqual(guid, ssgSearchRequest.SearchRequestId);
+            Assert.AreEqual(_validRequestGuid, ssgSearchRequest.SearchRequestId);
         }
 
         [Test]
         public async Task Notes_changed_ProcessUpdateSearchRequest_should_run_addNotes_correctly()
         {
-            Guid guid = Guid.NewGuid();
             Guid noteGuid = Guid.NewGuid();
-            Guid personGuid = Guid.NewGuid();
-            _searchRequestServiceMock.Setup(x => x.GetSearchRequest(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult<SSG_SearchRequest>(new SSG_SearchRequest()
-                {
-                    SearchRequestId = guid,
-                    PersonSoughtFirstName = "firstName",
-                    PersonSoughtLastName = "lastName",
-                    Notes = "note1",
-                    SSG_Notes = new List<SSG_Notese>().ToArray(),
-                    SSG_Persons = new List<SSG_Person>()
-                    {
-                        new SSG_Person()
-                        {
-                            PersonId=personGuid, FirstName = "firstName", LastName="lastName", InformationSource= InformationSourceType.Request.Value
-                        }
-                    }.ToArray()
-                }));
-
             _searchRequestServiceMock.Setup(x => x.GetPerson(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult<SSG_Person>(new SSG_Person()
                 {
-                    PersonId = personGuid,
+                    PersonId = _personGuid,
                     LastName = "lastName",
                     FirstName = "firstName"
                 }));
@@ -510,35 +279,16 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
             _searchRequestServiceMock.Verify(m => m.CreateNotes(It.IsAny<NotesEntity>()
                 , It.IsAny<CancellationToken>()), Times.Once);
 
-            Assert.AreEqual(guid, ssgSearchRequest.SearchRequestId);
+            Assert.AreEqual(_validRequestGuid, ssgSearchRequest.SearchRequestId);
         }
 
         [Test]
         public async Task RelatedPerson_changed_ProcessUpdateSearchRequest_should_run_updateRelatedPerson_correctly()
         {
-            Guid guid = Guid.NewGuid();
-            Guid personGuid = Guid.NewGuid();
-            _searchRequestServiceMock.Setup(x => x.GetSearchRequest(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult<SSG_SearchRequest>(new SSG_SearchRequest()
-                {
-                    SearchRequestId = guid,
-                    PersonSoughtFirstName = "firstName",
-                    PersonSoughtLastName = "lastName",
-                    Notes = "note1",
-                    SSG_Notes = new List<SSG_Notese>().ToArray(),
-                    SSG_Persons = new List<SSG_Person>()
-                    {
-                        new SSG_Person()
-                        {
-                            PersonId=personGuid, FirstName = "firstName", LastName="lastName", InformationSource= InformationSourceType.Request.Value
-                        }
-                    }.ToArray()
-                }));
-
             _searchRequestServiceMock.Setup(x => x.GetPerson(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult<SSG_Person>(new SSG_Person()
                 {
-                    PersonId = personGuid,
+                    PersonId = _personGuid,
                     LastName = "lastName",
                     FirstName = "firstName",
                     SSG_Identities = new List<SSG_Identity>() {
@@ -546,19 +296,32 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
                             FirstName = "child",
                             LastName = "lastName",
                             InformationSource = InformationSourceType.Request.Value,
-                            PersonType = RelatedPersonPersonType.Relation.Value
+                            PersonType = RelatedPersonPersonType.Relation.Value,
+                            IsCreatedByAgency=true
                         }
                     }.ToArray()
                 }));
 
-            SearchRequestEntity newSearchRequest = new SearchRequestEntity()
-            {
-            };
+            _searchRequestServiceMock.Setup(x => x.UpdateRelatedPerson(It.IsAny<SSG_Identity>(), It.IsAny<CancellationToken>()))
+                    .Returns(Task.FromResult<SSG_Identity>(new SSG_Identity()
+                    {
+                    RelatedPersonId = Guid.NewGuid()
+                    }));
+
+            SearchRequestEntity newSearchRequest = new SearchRequestEntity() { };
+
             _mapper.Setup(m => m.Map<SearchRequestEntity>(It.IsAny<SearchRequestOrdered>()))
                 .Returns(newSearchRequest);
 
             _mapper.Setup(m => m.Map<PersonEntity>(It.IsAny<Person>()))
                .Returns(new PersonEntity() { FirstName = "firstName", LastName = "lastName" });
+
+            _mapper.Setup(m => m.Map<RelatedPersonEntity>(It.IsAny<RelatedPerson>()))
+                   .Returns(new RelatedPersonEntity
+                   {
+                       LastName = "relatedChild",
+                       PersonType = RelatedPersonPersonType.Relation.Value
+                   });
 
             _searchRequstOrdered = new SearchRequestOrdered()
             {
@@ -583,35 +346,16 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
             _searchRequestServiceMock.Verify(m => m.UpdateRelatedPerson(It.IsAny<SSG_Identity>()
             , It.IsAny<CancellationToken>()), Times.Once);
 
-            Assert.AreEqual(guid, ssgSearchRequest.SearchRequestId);
+            Assert.AreEqual(_validRequestGuid, ssgSearchRequest.SearchRequestId);
         }
 
         [Test]
         public async Task RelatedPerson_added_ProcessUpdateSearchRequest_should_run_addRelatedPerson_correctly()
         {
-            Guid guid = Guid.NewGuid();
-            Guid personGuid = Guid.NewGuid();
-            _searchRequestServiceMock.Setup(x => x.GetSearchRequest(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult<SSG_SearchRequest>(new SSG_SearchRequest()
-                {
-                    SearchRequestId = guid,
-                    PersonSoughtFirstName = "firstName",
-                    PersonSoughtLastName = "lastName",
-                    Notes = "note1",
-                    SSG_Notes = new List<SSG_Notese>().ToArray(),
-                    SSG_Persons = new List<SSG_Person>()
-                    {
-                        new SSG_Person()
-                        {
-                            PersonId=personGuid, FirstName = "firstName", LastName="lastName", InformationSource= InformationSourceType.Request.Value
-                        }
-                    }.ToArray()
-                }));
-
             _searchRequestServiceMock.Setup(x => x.GetPerson(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult<SSG_Person>(new SSG_Person()
                 {
-                    PersonId = personGuid,
+                    PersonId = _personGuid,
                     LastName = "lastName",
                     FirstName = "firstName",
                     SSG_Identities = new List<SSG_Identity>() {
@@ -619,7 +363,8 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
                             FirstName = "child",
                             LastName = "lastName",
                             InformationSource = InformationSourceType.ICBC.Value,
-                            PersonType = RelatedPersonPersonType.Relation.Value
+                            PersonType = RelatedPersonPersonType.Relation.Value,
+                            IsCreatedByAgency=true
                         }
                     }.ToArray()
                 }));
@@ -669,7 +414,7 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
             _searchRequestServiceMock.Verify(m => m.CreateRelatedPerson(It.Is<RelatedPersonEntity>(m=>m.FirstName=="newFirstName")
             , It.IsAny<CancellationToken>()), Times.Once);
 
-            Assert.AreEqual(guid, ssgSearchRequest.SearchRequestId);
+            Assert.AreEqual(_validRequestGuid, ssgSearchRequest.SearchRequestId);
         }
 
         [Test]
@@ -689,7 +434,11 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
                     {
                         new SSG_Person()
                         {
-                            PersonId=personGuid, FirstName = "firstName", LastName="lastName", InformationSource= InformationSourceType.Request.Value
+                            PersonId=personGuid, 
+                            FirstName = "firstName", 
+                            LastName="lastName", 
+                            InformationSource= InformationSourceType.Request.Value,
+                            IsCreatedByAgency=true
                         }
                     }.ToArray()
                 }));
@@ -705,7 +454,8 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
                             FirstName = "applicantFirstName",
                             LastName = "applicantLastName",
                             InformationSource = InformationSourceType.Request.Value,
-                            PersonType = RelatedPersonPersonType.Applicant.Value
+                            PersonType = RelatedPersonPersonType.Applicant.Value,
+                            IsCreatedByAgency=true
                         }
                     }.ToArray()
                 }));
@@ -721,7 +471,7 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
             _mapper.Setup(m => m.Map<PersonEntity>(It.IsAny<Person>()))
                .Returns(new PersonEntity() { FirstName = "firstName", LastName = "lastName" });
 
-            _searchRequstOrdered = new SearchRequestOrdered()
+            SearchRequestOrdered searchRequstOrdered = new SearchRequestOrdered()
             {
                 Action = RequestAction.UPDATE,
                 RequestId = "1111111",
@@ -736,7 +486,7 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
                     }
                 }
             };
-            SSG_SearchRequest ssgSearchRequest = await _sut.ProcessUpdateSearchRequest(_searchRequstOrdered);
+            SSG_SearchRequest ssgSearchRequest = await _sut.ProcessUpdateSearchRequest(searchRequstOrdered);
             _searchRequestServiceMock.Verify(m => m.UpdateSearchRequest(It.IsAny<SSG_SearchRequest>(),
                  It.IsAny<CancellationToken>()), Times.Once);
             _searchRequestServiceMock.Verify(m => m.UpdatePerson(It.IsAny<SSG_Person>()
@@ -764,7 +514,11 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
                     {
                         new SSG_Person()
                         {
-                            PersonId=personGuid, FirstName = "firstName", LastName="lastName", InformationSource= InformationSourceType.Request.Value
+                            PersonId=personGuid,
+                            FirstName = "firstName",
+                            LastName="lastName",
+                            InformationSource= InformationSourceType.Request.Value,
+                            IsCreatedByAgency=true
                         }
                     }.ToArray()
                 }));
@@ -780,7 +534,8 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
                         new SSG_Employment()
                         {
                             BusinessName="existingBusinessName",
-                            InformationSource = InformationSourceType.Request.Value
+                            InformationSource = InformationSourceType.Request.Value,
+                            IsCreatedByAgency=true
                         }
                     }.ToArray()
                 }));
@@ -804,7 +559,10 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
             _mapper.Setup(m => m.Map<PersonEntity>(It.IsAny<Person>()))
                .Returns(new PersonEntity() { FirstName = "firstName", LastName = "lastName" });
 
-            _searchRequstOrdered = new SearchRequestOrdered()
+            _mapper.Setup(m => m.Map<EmploymentContactEntity>(It.IsAny<Phone>()))
+             .Returns(new EmploymentContactEntity { PhoneNumber = "11111111" });
+
+            SearchRequestOrdered searchRequstOrdered = new SearchRequestOrdered()
             {
                 Action = RequestAction.UPDATE,
                 RequestId = "1111111",
@@ -826,7 +584,7 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
                     }
                 }
             };
-            SSG_SearchRequest ssgSearchRequest = await _sut.ProcessUpdateSearchRequest(_searchRequstOrdered);
+            SSG_SearchRequest ssgSearchRequest = await _sut.ProcessUpdateSearchRequest(searchRequstOrdered);
             _searchRequestServiceMock.Verify(m => m.UpdateSearchRequest(It.IsAny<SSG_SearchRequest>(),
                  It.IsAny<CancellationToken>()), Times.Never);
             _searchRequestServiceMock.Verify(m => m.UpdatePerson(It.IsAny<SSG_Person>()
@@ -846,27 +604,10 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
         [Test]
         public async Task Employment_added_ProcessUpdateSearchRequest_should_run_addEmployment_correctly()
         {
-            Guid guid = Guid.NewGuid();
-            Guid personGuid = Guid.NewGuid();
-            _searchRequestServiceMock.Setup(x => x.GetSearchRequest(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult<SSG_SearchRequest>(new SSG_SearchRequest()
-                {
-                    SearchRequestId = guid,
-                    PersonSoughtFirstName = "firstName",
-                    PersonSoughtLastName = "lastName",
-                    SSG_Persons = new List<SSG_Person>()
-                    {
-                        new SSG_Person()
-                        {
-                            PersonId=personGuid, FirstName = "firstName", LastName="lastName", InformationSource= InformationSourceType.Request.Value
-                        }
-                    }.ToArray()
-                }));
-
             _searchRequestServiceMock.Setup(x => x.GetPerson(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult<SSG_Person>(new SSG_Person()
                 {
-                    PersonId = personGuid,
+                    PersonId = _personGuid,
                     LastName = "lastName",
                     FirstName = "firstName",                   
                 }));
@@ -886,6 +627,9 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
 
             _mapper.Setup(m => m.Map<EmploymentEntity>(It.IsAny<Employment>()))
                 .Returns(new EmploymentEntity() { BusinessName = "Changed" });
+
+            _mapper.Setup(m => m.Map<EmploymentContactEntity>(It.IsAny<Phone>()))
+                .Returns(new EmploymentContactEntity{PhoneNumber = "11111111"});
 
             _mapper.Setup(m => m.Map<PersonEntity>(It.IsAny<Person>()))
                .Returns(new PersonEntity() { FirstName = "firstName", LastName = "lastName" });
@@ -926,39 +670,22 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
             _searchRequestServiceMock.Verify(m => m.CreateEmploymentContact(It.IsAny<EmploymentContactEntity>()
                 , It.IsAny<CancellationToken>()), Times.Once);
 
-            Assert.AreEqual(guid, ssgSearchRequest.SearchRequestId);
+            Assert.AreEqual(_validRequestGuid, ssgSearchRequest.SearchRequestId);
         }
 
         [Test]
         public async Task Addresses_changed_ProcessUpdateSearchRequest_should_run_addAddress_correctly()
         {
-            Guid guid = Guid.NewGuid();
-            Guid personGuid = Guid.NewGuid();
-            _searchRequestServiceMock.Setup(x => x.GetSearchRequest(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult<SSG_SearchRequest>(new SSG_SearchRequest()
-                {
-                    SearchRequestId = guid,
-                    PersonSoughtFirstName = "firstName",
-                    PersonSoughtLastName = "lastName",
-                    SSG_Persons = new List<SSG_Person>()
-                    {
-                        new SSG_Person()
-                        {
-                            PersonId=personGuid, FirstName = "firstName", LastName="lastName", InformationSource= InformationSourceType.Request.Value
-                        }
-                    }.ToArray()
-                }));
-
             _searchRequestServiceMock.Setup(x => x.GetPerson(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult<SSG_Person>(new SSG_Person()
                 {
-                    PersonId = personGuid,
+                    PersonId = _personGuid,
                     LastName = "lastName",
                     FirstName = "firstName",
                     SSG_Addresses = new List<SSG_Address>() {
                         new SSG_Address()
                         {
-                            AddressLine1 = "addressLine1", AddressLine2="line2"
+                            AddressLine1 = "addressLine1", AddressLine2="line2", IsCreatedByAgency=true
                         }
                     }.ToArray()
                 })); 
@@ -974,7 +701,7 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
             _mapper.Setup(m => m.Map<PersonEntity>(It.IsAny<Person>()))
                .Returns(new PersonEntity() { FirstName = "firstName", LastName = "lastName" });
 
-            _searchRequstOrdered = new SearchRequestOrdered()
+            SearchRequestOrdered searchRequstOrdered = new SearchRequestOrdered()
             {
                 Action = RequestAction.UPDATE,
                 RequestId = "1111111",
@@ -992,7 +719,7 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
                     }
                 }
             };
-            SSG_SearchRequest ssgSearchRequest = await _sut.ProcessUpdateSearchRequest(_searchRequstOrdered);
+            SSG_SearchRequest ssgSearchRequest = await _sut.ProcessUpdateSearchRequest(searchRequstOrdered);
             _searchRequestServiceMock.Verify(m => m.UpdateSearchRequest(It.IsAny<SSG_SearchRequest>(),
                  It.IsAny<CancellationToken>()), Times.Never);
             _searchRequestServiceMock.Verify(m => m.UpdatePerson(It.IsAny<SSG_Person>()
@@ -1008,33 +735,16 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
             _searchRequestServiceMock.Verify(m => m.CreateAddress(It.IsAny<AddressEntity>()
                 , It.IsAny<CancellationToken>()), Times.Once);
 
-            Assert.AreEqual(guid, ssgSearchRequest.SearchRequestId);
+            Assert.AreEqual(_validRequestGuid, ssgSearchRequest.SearchRequestId);
         }
 
         [Test]
         public async Task Phones_changed_ProcessUpdateSearchRequest_should_run_addPhones_correctly()
         {
-            Guid guid = Guid.NewGuid();
-            Guid personGuid = Guid.NewGuid();
-            _searchRequestServiceMock.Setup(x => x.GetSearchRequest(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult<SSG_SearchRequest>(new SSG_SearchRequest()
-                {
-                    SearchRequestId = guid,
-                    PersonSoughtFirstName = "firstName",
-                    PersonSoughtLastName = "lastName",
-                    SSG_Persons = new List<SSG_Person>()
-                    {
-                        new SSG_Person()
-                        {
-                            PersonId=personGuid, FirstName = "firstName", LastName="lastName", InformationSource= InformationSourceType.Request.Value
-                        }
-                    }.ToArray()
-                }));
-
             _searchRequestServiceMock.Setup(x => x.GetPerson(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult<SSG_Person>(new SSG_Person()
                 {
-                    PersonId = personGuid,
+                    PersonId = _personGuid,
                     LastName = "lastName",
                     FirstName = "firstName",
                     SSG_PhoneNumbers = new List<SSG_PhoneNumber>() {
@@ -1092,33 +802,16 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
             _searchRequestServiceMock.Verify(m => m.CreatePhoneNumber(It.IsAny<PhoneNumberEntity>()
                 , It.IsAny<CancellationToken>()), Times.Once);
 
-            Assert.AreEqual(guid, ssgSearchRequest.SearchRequestId);
+            Assert.AreEqual(_validRequestGuid, ssgSearchRequest.SearchRequestId);
         }
 
         [Test]
         public async Task Identifiers_changed_ProcessUpdateSearchRequest_should_run_updateIdentifiers_correctly()
         {
-            Guid guid = Guid.NewGuid();
-            Guid personGuid = Guid.NewGuid();
-            _searchRequestServiceMock.Setup(x => x.GetSearchRequest(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult<SSG_SearchRequest>(new SSG_SearchRequest()
-                {
-                    SearchRequestId = guid,
-                    PersonSoughtFirstName = "firstName",
-                    PersonSoughtLastName = "lastName",
-                    SSG_Persons = new List<SSG_Person>()
-                    {
-                        new SSG_Person()
-                        {
-                            PersonId=personGuid, FirstName = "firstName", LastName="lastName", InformationSource= InformationSourceType.Request.Value
-                        }
-                    }.ToArray()
-                }));
-
             _searchRequestServiceMock.Setup(x => x.GetPerson(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult<SSG_Person>(new SSG_Person()
                 {
-                    PersonId = personGuid,
+                    PersonId = _personGuid,
                     LastName = "lastName",
                     FirstName = "firstName",
                     SSG_Identifiers = new List<SSG_Identifier>()
@@ -1127,7 +820,8 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
                         {
                             Identification="222222",
                             IdentifierType = IdentificationType.BCDriverLicense.Value,
-                            InformationSource = InformationSourceType.Request.Value
+                            InformationSource = InformationSourceType.Request.Value,
+                            IsCreatedByAgency=true
                         }
                     }.ToArray()
                 }));
@@ -1179,33 +873,16 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
             _searchRequestServiceMock.Verify(m => m.UpdateIdentifier(It.IsAny<SSG_Identifier>()
                 , It.IsAny<CancellationToken>()), Times.Once);
 
-            Assert.AreEqual(guid, ssgSearchRequest.SearchRequestId);
+            Assert.AreEqual(_validRequestGuid, ssgSearchRequest.SearchRequestId);
         }
 
         [Test]
         public async Task Identifiers_added_ProcessUpdateSearchRequest_should_run_addIdentifiers_correctly()
         {
-            Guid guid = Guid.NewGuid();
-            Guid personGuid = Guid.NewGuid();
-            _searchRequestServiceMock.Setup(x => x.GetSearchRequest(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult<SSG_SearchRequest>(new SSG_SearchRequest()
-                {
-                    SearchRequestId = guid,
-                    PersonSoughtFirstName = "firstName",
-                    PersonSoughtLastName = "lastName",
-                    SSG_Persons = new List<SSG_Person>()
-                    {
-                        new SSG_Person()
-                        {
-                            PersonId=personGuid, FirstName = "firstName", LastName="lastName", InformationSource= InformationSourceType.Request.Value
-                        }
-                    }.ToArray()
-                }));
-
             _searchRequestServiceMock.Setup(x => x.GetPerson(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult<SSG_Person>(new SSG_Person()
                 {
-                    PersonId = personGuid,
+                    PersonId = _personGuid,
                     LastName = "lastName",
                     FirstName = "firstName",
                     SSG_Identifiers = new List<SSG_Identifier>()
@@ -1266,7 +943,7 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
             _searchRequestServiceMock.Verify(m => m.CreateIdentifier(It.IsAny<IdentifierEntity>()
                 , It.IsAny<CancellationToken>()), Times.Once);
 
-            Assert.AreEqual(guid, ssgSearchRequest.SearchRequestId);
+            Assert.AreEqual(_validRequestGuid, ssgSearchRequest.SearchRequestId);
         }
 
         [Test]

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/Mapping/Contructors.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/Mapping/Contructors.cs
@@ -46,7 +46,7 @@ namespace DynamicsAdapter.Web.Mapping
                         case "phonenumber": entity.PhoneNumberRequested = true; break;
                         case "carceration": entity.CarcerationStatusRequested = true; break;
                         case "dateofdeath": entity.DateOfDeathRequested = true; break;
-                        case "iastatus": entity.IAStatusRequested = true; break;
+                        case "ia": entity.IAStatusRequested = true; break;
                         case "safety": entity.SafetyConcernRequested = true; break;
                     };
                 }

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/AgencyRequestService.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/AgencyRequestService.cs
@@ -293,7 +293,7 @@ namespace DynamicsAdapter.Web.SearchAgency
             if (ssgMerged.Updated)
             {
                 ssgMerged.SearchRequest = _uploadedPerson.SearchRequest;
-                ssgMerged = await _searchRequestService.UpdatePerson(ssgMerged, _cancellationToken);
+                await _searchRequestService.UpdatePerson(ssgMerged, _cancellationToken);
                 _logger.LogInformation("Update Person successfully");
             }
             return true;

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/AgencyRequestService.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/AgencyRequestService.cs
@@ -64,6 +64,7 @@ namespace DynamicsAdapter.Web.SearchAgency
             PersonEntity personEntity = _mapper.Map<PersonEntity>(_personSought);
             personEntity.SearchRequest = _uploadedSearchRequest;
             personEntity.InformationSource = InformationSourceType.Request.Value;
+            personEntity.IsCreatedByAgency = true;
             _uploadedPerson = await _searchRequestService.SavePerson(personEntity, _cancellationToken);
             _logger.LogInformation("Create Person successfully");
 
@@ -106,7 +107,8 @@ namespace DynamicsAdapter.Web.SearchAgency
             SSG_Person existedSoughtPerson = existedSearchRequest?.SSG_Persons?.FirstOrDefault(
                     m => m.FirstName == existedSearchRequest.PersonSoughtFirstName
                     && m.LastName == existedSearchRequest.PersonSoughtLastName
-                    && m.InformationSource == InformationSourceType.Request.Value);
+                    && m.InformationSource == InformationSourceType.Request.Value
+                    && m.IsCreatedByAgency);
             if (existedSoughtPerson == null)
             {
                 _logger.LogError("the updating personSought does not exist. something is wrong.");
@@ -169,6 +171,7 @@ namespace DynamicsAdapter.Web.SearchAgency
                 identifier.SearchRequest = _uploadedSearchRequest;
                 identifier.InformationSource = InformationSourceType.Request.Value;
                 identifier.Person = _uploadedPerson;
+                identifier.IsCreatedByAgency = true;
                 SSG_Identifier newIdentifier = await _searchRequestService.CreateIdentifier(identifier, _cancellationToken);
             }
             _logger.LogInformation("Create identifier records for SearchRequest successfully");
@@ -187,6 +190,7 @@ namespace DynamicsAdapter.Web.SearchAgency
                 addr.SearchRequest = _uploadedSearchRequest;
                 addr.InformationSource = InformationSourceType.Request.Value;
                 addr.Person = _uploadedPerson;
+                addr.IsCreatedByAgency = true;
                 SSG_Address uploadedAddr = await _searchRequestService.CreateAddress(addr, _cancellationToken);
             }
             _logger.LogInformation("Create addresses records for SearchRequest successfully");
@@ -205,6 +209,7 @@ namespace DynamicsAdapter.Web.SearchAgency
                 ph.SearchRequest = _uploadedSearchRequest;
                 ph.InformationSource = InformationSourceType.Request.Value;
                 ph.Person = _uploadedPerson;
+                ph.IsCreatedByAgency = true;
                 SSG_PhoneNumber uploadedPhone = await _searchRequestService.CreatePhoneNumber(ph, _cancellationToken);
             }
             _logger.LogInformation("Create phones records for SearchRequest successfully");
@@ -223,6 +228,7 @@ namespace DynamicsAdapter.Web.SearchAgency
                 e.SearchRequest = _uploadedSearchRequest;
                 e.InformationSource = InformationSourceType.Request.Value;
                 e.Person = _uploadedPerson;
+                e.IsCreatedByAgency = true;
                 SSG_Employment ssg_employment = await _searchRequestService.CreateEmployment(e, _cancellationToken);
 
                 if (employment.Employer != null)
@@ -252,6 +258,7 @@ namespace DynamicsAdapter.Web.SearchAgency
                 n.SearchRequest = _uploadedSearchRequest;
                 n.InformationSource = InformationSourceType.Request.Value;
                 n.Person = _uploadedPerson;
+                n.IsCreatedByAgency = true;
                 SSG_Identity relate = await _searchRequestService.CreateRelatedPerson(n, _cancellationToken);
 
             }
@@ -298,7 +305,9 @@ namespace DynamicsAdapter.Web.SearchAgency
 
             //update or add relation relatedPerson
             SSG_Identity originalRelatedPerson= _uploadedPerson?.SSG_Identities?.FirstOrDefault(
-            m => m.InformationSource == InformationSourceType.Request.Value && m.PersonType == RelatedPersonPersonType.Relation.Value);
+            m => m.InformationSource == InformationSourceType.Request.Value 
+            && m.PersonType == RelatedPersonPersonType.Relation.Value
+            && m.IsCreatedByAgency);
 
             if (_personSought.RelatedPersons?.Count() > 0)
             {
@@ -329,7 +338,8 @@ namespace DynamicsAdapter.Web.SearchAgency
 
             //update or add relation relatedPerson
             SSG_Identity originalRelatedApplicant = _uploadedPerson.SSG_Identities?.FirstOrDefault(
-            m => m.InformationSource == InformationSourceType.Request.Value && m.PersonType == RelatedPersonPersonType.Applicant.Value);
+            m => m.InformationSource == InformationSourceType.Request.Value 
+            && m.PersonType == RelatedPersonPersonType.Applicant.Value);
 
             if (originalRelatedApplicant == null)
             {
@@ -362,7 +372,8 @@ namespace DynamicsAdapter.Web.SearchAgency
             _logger.LogDebug($"Attempting to update employment records for PersonSought.");
 
             SSG_Employment originalEmployment = _uploadedPerson.SSG_Employments?.FirstOrDefault(
-                    m => m.InformationSource == InformationSourceType.Request.Value );
+                    m => m.InformationSource == InformationSourceType.Request.Value 
+                    && m.IsCreatedByAgency);
 
             if (_personSought.Employments.Count() > 0)
             {
@@ -410,7 +421,9 @@ namespace DynamicsAdapter.Web.SearchAgency
             {
                 IdentifierEntity identifierEntity = _mapper.Map<IdentifierEntity>(pi);
                 SSG_Identifier originalIdentifier = _uploadedPerson.SSG_Identifiers?.FirstOrDefault(
-                   m => m.InformationSource == InformationSourceType.Request.Value && m.IdentifierType==identifierEntity.IdentifierType);
+                   m => m.InformationSource == InformationSourceType.Request.Value 
+                        && m.IdentifierType==identifierEntity.IdentifierType
+                        && m.IsCreatedByAgency);
                 if(originalIdentifier == null)
                 {
                     await UploadIdentifiers();

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/AgencyRequestService.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/AgencyRequestService.cs
@@ -139,8 +139,7 @@ namespace DynamicsAdapter.Web.SearchAgency
             PersonEntity newPersonEntity = _mapper.Map<PersonEntity>(_personSought);
             await UpdatePersonSought(newPersonEntity);
 
-            //update RelatedPerson
-            await UpdateRelatedPerson();
+            //update RelatedPerson applicant
             await UpdateRelatedApplicant((string.IsNullOrEmpty(newSearchRequest.ApplicantFirstName)|| string.IsNullOrEmpty(newSearchRequest.ApplicantLastName))? null : new RelatedPersonEntity()
                                             {
                                                 FirstName = newSearchRequest.ApplicantFirstName,
@@ -152,10 +151,11 @@ namespace DynamicsAdapter.Web.SearchAgency
             //update identifiers
             await UpdateIdentifiers();
 
-            //for phones, addresses, Identifiers are same as creation, as if different, add new one, if same, ignore
+            //for phones, addresses, relatedPersons are same as creation, as if different, add new one, if same, ignore
             await UploadAddresses();
             await UploadPhones();
-            
+            await UploadRelatedPersons();
+
 
             return _uploadedSearchRequest;
         }

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/AgencyRequestService.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/AgencyRequestService.cs
@@ -293,6 +293,12 @@ namespace DynamicsAdapter.Web.SearchAgency
             if (ssgMerged.Updated)
             {
                 ssgMerged.SearchRequest = _uploadedPerson.SearchRequest;
+                ssgMerged.IsCreatedByAgency = true;
+                ssgMerged.SSG_Addresses = null;
+                ssgMerged.SSG_Employments = null;
+                ssgMerged.SSG_Identifiers = null;
+                ssgMerged.SSG_Identities = null;
+                ssgMerged.SSG_PhoneNumbers = null;
                 await _searchRequestService.UpdatePerson(ssgMerged, _cancellationToken);
                 _logger.LogInformation("Update Person successfully");
             }

--- a/app/DynamicsAdapter/Fams3Adapter.Dynamics.Test/SearchRequest/SearchRequestService_Person_Test.cs
+++ b/app/DynamicsAdapter/Fams3Adapter.Dynamics.Test/SearchRequest/SearchRequestService_Person_Test.cs
@@ -169,6 +169,7 @@ namespace Fams3Adapter.Dynamics.Test.SearchRequest
                 .Expand(x => x.SSG_Identifiers)
                 .Expand(x => x.SSG_Employments)
                 .Expand(x => x.SSG_Addresses)
+                .Expand(x=>x.SSG_Aliases)
                 .FindEntryAsync(It.IsAny<CancellationToken>()))
                .Returns(Task.FromResult<SSG_Person>(new SSG_Person()
                {

--- a/app/DynamicsAdapter/Fams3Adapter.Dynamics/Address/SSG_Address.cs
+++ b/app/DynamicsAdapter/Fams3Adapter.Dynamics/Address/SSG_Address.cs
@@ -58,6 +58,9 @@ namespace Fams3Adapter.Dynamics.Address
 
         [JsonProperty("ssg_notes")]
         public string Notes { get; set; }
+
+        [JsonProperty("ssg_createdbyagency")]
+        public bool IsCreatedByAgency { get; set; }
     }
 
     public class SSG_Address : AddressEntity

--- a/app/DynamicsAdapter/Fams3Adapter.Dynamics/Employment/SSG_Employment.cs
+++ b/app/DynamicsAdapter/Fams3Adapter.Dynamics/Employment/SSG_Employment.cs
@@ -76,6 +76,9 @@ namespace Fams3Adapter.Dynamics.Employment
         public virtual SSG_SearchRequest SearchRequest { get; set; }
 
         public virtual EmploymentContactEntity[] EmploymentContactEntities { get; set; }
+
+        [JsonProperty("ssg_createdbyagency")]
+        public bool IsCreatedByAgency { get; set; }
     }
 
     public class SSG_Employment : EmploymentEntity

--- a/app/DynamicsAdapter/Fams3Adapter.Dynamics/Identifier/SSG_Identifier.cs
+++ b/app/DynamicsAdapter/Fams3Adapter.Dynamics/Identifier/SSG_Identifier.cs
@@ -33,6 +33,9 @@ namespace Fams3Adapter.Dynamics.Identifier
 
         [JsonProperty("ssg_informationsourcetext")]
         public int? InformationSource { get; set; }
+
+        [JsonProperty("ssg_createdbyagency")]
+        public bool IsCreatedByAgency { get; set; }
     }
 
     public class SSG_Identifier : IdentifierEntity

--- a/app/DynamicsAdapter/Fams3Adapter.Dynamics/Name/SSG_Alias.cs
+++ b/app/DynamicsAdapter/Fams3Adapter.Dynamics/Name/SSG_Alias.cs
@@ -42,6 +42,9 @@ namespace Fams3Adapter.Dynamics.Name
 
         [JsonProperty("ssg_notes")]
         public string Notes { get; set; }
+
+        [JsonProperty("ssg_createdbyagency")]
+        public bool IsCreatedByAgency { get; set; }
     }
 
     public class SSG_Aliase : AliasEntity

--- a/app/DynamicsAdapter/Fams3Adapter.Dynamics/Person/SSG_Person.cs
+++ b/app/DynamicsAdapter/Fams3Adapter.Dynamics/Person/SSG_Person.cs
@@ -79,6 +79,9 @@ namespace Fams3Adapter.Dynamics.Person
 
         [JsonProperty("ssg_duplicatedetectionhash")]
         public string DuplicateDetectHash { get; set; }
+
+        [JsonProperty("ssg_createdbyagency")]
+        public bool IsCreatedByAgency { get; set; }
     }
 
     public class SSG_Person : PersonEntity

--- a/app/DynamicsAdapter/Fams3Adapter.Dynamics/Phone/SSG_PhoneNumber.cs
+++ b/app/DynamicsAdapter/Fams3Adapter.Dynamics/Phone/SSG_PhoneNumber.cs
@@ -34,6 +34,9 @@ namespace Fams3Adapter.Dynamics.PhoneNumber
         [JsonProperty("ssg_notes")]
         public string Notes { get; set; }
 
+        [JsonProperty("ssg_createdbyagency")]
+        public bool IsCreatedByAgency { get; set; }
+
     }
 
     public class SSG_PhoneNumber : PhoneNumberEntity

--- a/app/DynamicsAdapter/Fams3Adapter.Dynamics/RelatedPerson/SSG_RelatedPerson.cs
+++ b/app/DynamicsAdapter/Fams3Adapter.Dynamics/RelatedPerson/SSG_RelatedPerson.cs
@@ -48,6 +48,9 @@ namespace Fams3Adapter.Dynamics.RelatedPerson
 
         [JsonProperty("ssg_notes")]
         public string Notes { get; set; }
+
+        [JsonProperty("ssg_createdbyagency")]
+        public bool IsCreatedByAgency { get; set; }
     }
 
     public class SSG_Identity : RelatedPersonEntity

--- a/app/DynamicsAdapter/Fams3Adapter.Dynamics/SearchRequest/SearchRequestService.cs
+++ b/app/DynamicsAdapter/Fams3Adapter.Dynamics/SearchRequest/SearchRequestService.cs
@@ -422,6 +422,7 @@ namespace Fams3Adapter.Dynamics.SearchRequest
                 .Expand(x => x.SSG_Identifiers)
                 .Expand(x => x.SSG_Employments)
                 .Expand(x => x.SSG_Addresses)
+                .Expand(x => x.SSG_Aliases)
                 .FindEntryAsync(cancellationToken);
 
             return dataSearchRequest;


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- FAMS3-2569(add CreateByAgency and corresponding logic to searchRequest related entities.)

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Tested locally and unit tests

## Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
