### PR TITLE
add nosniff http header to all httpresponse

### DIFF
--- a/app/DynamicsAdapter/DynamicsAdapter.Web/Startup.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/Startup.cs
@@ -269,6 +269,7 @@ namespace DynamicsAdapter.Web
                      MaxAge = TimeSpan.FromSeconds(0),
 
                  };
+                context.Response.Headers.Add("X-Content-Type-Options", "nosniff");
                 await next();
             });
 

--- a/app/SearchApi/SearchApi.Web/Startup.cs
+++ b/app/SearchApi/SearchApi.Web/Startup.cs
@@ -244,6 +244,12 @@ namespace SearchApi.Web
 
             app.UseOpenApi();
 
+            app.Use(async (context, next) =>
+            {
+                context.Response.Headers.Add("X-Content-Type-Options", "nosniff");
+                await next();
+            });
+
             app.UseEndpoints(endpoints =>
             {
                 // registration of health endpoints see https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/health-checks

--- a/app/SearchApi/SearchRequest.Adaptor/Startup.cs
+++ b/app/SearchApi/SearchRequest.Adaptor/Startup.cs
@@ -84,6 +84,12 @@ namespace SearchRequestAdaptor
                 app.UseSwaggerUi3();
             }
 
+            app.Use(async (context, next) =>
+            {
+                context.Response.Headers.Add("X-Content-Type-Options", "nosniff");
+                await next();
+            });
+
             app.UseRouting();
             app.UseOpenApi();
             app.UseEndpoints(endpoints =>


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- FAMS3-2138([DynaAdapter - [DynamicsAdapter.Web]] The Anti-MIME-Sniffing header X-Content-Type-Options was not set to 'nosniff'.)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Tested locally

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
