### PR TITLE
Feature/3204-request Api: when dynadatpor failed in creating SR, we need retry to re-create SR.

### DIFF
--- a/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/AgencyRequestController.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/AgencyRequestController.cs
@@ -71,7 +71,7 @@ namespace DynamicsAdapter.Web.SearchAgency
                         await _agencyRequestService.SystemCancelSSGSearchRequest(createdSR);
                     }
                     _logger.LogError(ex.Message);
-                    return StatusCode(StatusCodes.Status500InternalServerError, new { ReasonCode = "error", Message = "error" });
+                    return StatusCode(StatusCodes.Status504GatewayTimeout, new { ReasonCode = "error", Message = "error" });
                 }
             }
         }

--- a/app/SearchApi/SearchRequest.Adaptor/Consumer/SearchRequestOrderedConsumer.cs
+++ b/app/SearchApi/SearchRequest.Adaptor/Consumer/SearchRequestOrderedConsumer.cs
@@ -3,6 +3,7 @@ using BcGov.Fams3.SearchApi.Core.Configuration;
 using MassTransit;
 
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using SearchRequestAdaptor.Notifier;
 using Serilog.Context;
 using System.Threading;
@@ -14,9 +15,9 @@ namespace SearchRequestAdaptor.Consumer
     {
         private readonly ILogger<SearchRequestOrderedConsumer> _logger;
         private readonly ISearchRequestNotifier<SearchRequestOrdered> _searchRequestNotifier;
-        private readonly RetryConfiguration _retryConfig;
+        private readonly IOptions<RetryConfiguration>  _retryConfig;
 
-        public SearchRequestOrderedConsumer(ISearchRequestNotifier<SearchRequestOrdered> searchRequestNotifier, ILogger<SearchRequestOrderedConsumer> logger, RetryConfiguration retryConfig)
+        public SearchRequestOrderedConsumer(ISearchRequestNotifier<SearchRequestOrdered> searchRequestNotifier, ILogger<SearchRequestOrderedConsumer> logger, IOptions<RetryConfiguration> retryConfig)
         {
             _logger = logger;
             _searchRequestNotifier = searchRequestNotifier;
@@ -31,7 +32,7 @@ namespace SearchRequestAdaptor.Consumer
             {
                 _logger.LogInformation("get the searchRequestOrdered message.");
                 var cts = new CancellationTokenSource();
-                await _searchRequestNotifier.NotifySearchRequestEventAsync(context.Message.RequestId, context.Message, cts.Token, context.GetRetryAttempt(), _retryConfig.RetryTimes);
+                await _searchRequestNotifier.NotifySearchRequestEventAsync(context.Message.RequestId, context.Message, cts.Token, context.GetRetryAttempt(), _retryConfig.Value.RetryTimes);
             }
         }
 

--- a/app/SearchApi/SearchRequest.Adaptor/Consumer/SearchRequestOrderedConsumer.cs
+++ b/app/SearchApi/SearchRequest.Adaptor/Consumer/SearchRequestOrderedConsumer.cs
@@ -1,4 +1,5 @@
-﻿using BcGov.Fams3.SearchApi.Contracts.SearchRequest;
+using BcGov.Fams3.SearchApi.Contracts.SearchRequest;
+using BcGov.Fams3.SearchApi.Core.Configuration;
 using MassTransit;
 
 using Microsoft.Extensions.Logging;
@@ -13,11 +14,13 @@ namespace SearchRequestAdaptor.Consumer
     {
         private readonly ILogger<SearchRequestOrderedConsumer> _logger;
         private readonly ISearchRequestNotifier<SearchRequestOrdered> _searchRequestNotifier;
+        private readonly RetryConfiguration _retryConfig;
 
-        public SearchRequestOrderedConsumer(ISearchRequestNotifier<SearchRequestOrdered> searchRequestNotifier, ILogger<SearchRequestOrderedConsumer> logger)
+        public SearchRequestOrderedConsumer(ISearchRequestNotifier<SearchRequestOrdered> searchRequestNotifier, ILogger<SearchRequestOrderedConsumer> logger, RetryConfiguration retryConfig)
         {
             _logger = logger;
             _searchRequestNotifier = searchRequestNotifier;
+            _retryConfig = retryConfig;
 
         }
 
@@ -28,7 +31,7 @@ namespace SearchRequestAdaptor.Consumer
             {
                 _logger.LogInformation("get the searchRequestOrdered message.");
                 var cts = new CancellationTokenSource();
-                await _searchRequestNotifier.NotifySearchRequestEventAsync(context.Message.RequestId, context.Message, cts.Token);
+                await _searchRequestNotifier.NotifySearchRequestEventAsync(context.Message.RequestId, context.Message, cts.Token, context.GetRetryAttempt(), _retryConfig.RetryTimes);
             }
         }
 

--- a/app/SearchApi/SearchRequest.Adaptor/Notifier/SearchRequestNotifier.cs
+++ b/app/SearchApi/SearchRequest.Adaptor/Notifier/SearchRequestNotifier.cs
@@ -112,6 +112,7 @@ namespace SearchRequestAdaptor.Notifier
                         }
                         else
                         {
+                            _logger.LogError($"Message Failed { response.StatusCode}, {response.Content.ReadAsStringAsync()}");
                             throw new Exception($"Message Failed {response.StatusCode}, {response.Content.ReadAsStringAsync()}");
                         }
                     }

--- a/app/SearchApi/SearchRequest.Adaptor/Notifier/SearchRequestNotifier.cs
+++ b/app/SearchApi/SearchRequest.Adaptor/Notifier/SearchRequestNotifier.cs
@@ -1,4 +1,4 @@
-﻿using BcGov.Fams3.SearchApi.Contracts.Person;
+using BcGov.Fams3.SearchApi.Contracts.Person;
 using BcGov.Fams3.SearchApi.Contracts.PersonSearch;
 using BcGov.Fams3.SearchApi.Contracts.SearchRequest;
 using BcGov.Fams3.Utils.Url;
@@ -18,7 +18,7 @@ namespace SearchRequestAdaptor.Notifier
 {
     public interface ISearchRequestNotifier<T>
     {
-        Task NotifySearchRequestEventAsync(string requestId, T searchRequestOrdered, CancellationToken cancellationToken);
+        Task NotifySearchRequestEventAsync(string requestId, T searchRequestOrdered, CancellationToken cancellationToken, int retryTimes=0, int maxRetryTimes=0);
     }
 
     public class WebHookSearchRequestNotifier : ISearchRequestNotifier<SearchRequestOrdered>
@@ -39,7 +39,7 @@ namespace SearchRequestAdaptor.Notifier
         }
 
         public async Task NotifySearchRequestEventAsync(string requestId, SearchRequestOrdered searchRequestOrdered,
-           CancellationToken cancellationToken)
+           CancellationToken cancellationToken, int retryTimes=0, int maxRetryTimes=0)
         {
             var webHookName = "SearchRequest";
 
@@ -131,8 +131,13 @@ namespace SearchRequestAdaptor.Notifier
                 }
                 catch (Exception exception)
                 {
-                    await _searchRequestEventPublisher.PublishSearchRequestFailed(searchRequestOrdered, exception.Message);
-                    _logger.LogError($"The webHook {webHookName} notification failed for {eventName} for {webHook.Name} webHook. [{exception.Message}]");
+                    if (retryTimes >= maxRetryTimes)
+                    {
+                        await _searchRequestEventPublisher.PublishSearchRequestFailed(searchRequestOrdered, exception.Message);
+                        _logger.LogError($"The webHook {webHookName} notification failed for {eventName} for {webHook.Name} webHook. [{exception.Message}]");
+                        return;
+                    }
+                    throw exception;
                 }
             }
         }

--- a/app/SearchApi/SearchRequest.Adaptor/appsettings.json
+++ b/app/SearchApi/SearchRequest.Adaptor/appsettings.json
@@ -29,6 +29,10 @@
     "Username": "guest",
     "Password": "guest"
   },
+  "RetryConfiguration": {
+    "RetryTimes": 3,
+    "RetryInterval":  2
+  },
   "SearchRequestAdaptor": {
     "WebHooks": [
       {
@@ -38,5 +42,5 @@
     ],
     "ApiKeyForDynadaptor": "6f975845-91a7-4038-830a-eb222b2559fe"
   }
-  
+
 }


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- request Api: when dynadatpor failed in creating SR, we need retry to re-create SR.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Tested locally and unit tests

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
