### PR TITLE
Fix/error queue

### DIFF
--- a/app/DynamicsAdapter/DynamicsAdapter.Web.Test/SearchAgency/AgencyRequestControllerTest.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web.Test/SearchAgency/AgencyRequestControllerTest.cs
@@ -368,7 +368,7 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
             var result = await _sut.UpdateSearchRequest("requestId", updateSearchRequestOrdered);
 
             _agencyRequestServiceMock.Verify(x => x.ProcessUpdateSearchRequest(It.IsAny<SearchRequestOrdered>()), Times.Once);
-            Assert.IsInstanceOf(typeof(BadRequestObjectResult), result);
+            Assert.AreEqual(500, ((ObjectResult)result).StatusCode);
         }
 
         [Test]

--- a/app/DynamicsAdapter/DynamicsAdapter.Web.Test/SearchAgency/AgencyRequestControllerTest.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web.Test/SearchAgency/AgencyRequestControllerTest.cs
@@ -128,7 +128,7 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
             var result = await _sut.CreateSearchRequest("exceptionrequest", updateSearchRequestOrdered);
             _agencyRequestServiceMock.Verify(x => x.ProcessSearchRequestOrdered(It.IsAny<SearchRequestOrdered>()), Times.Once);
             _agencyRequestServiceMock.Verify(x => x.SystemCancelSSGSearchRequest(It.Is<SSG_SearchRequest>(m=>m.FileId=="111111")), Times.Once);
-            Assert.AreEqual(504, ((ObjectResult)result).StatusCode);
+            Assert.AreEqual(500, ((ObjectResult)result).StatusCode);
         }
 
 
@@ -235,11 +235,11 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
                 SearchRequestKey = "notexist"
             };
             _agencyRequestServiceMock.Setup(x => x.ProcessCancelSearchRequest(It.IsAny<SearchRequestOrdered>()))
-                .Returns(Task.FromResult<SSG_SearchRequest>(null));
+                .ThrowsAsync(new Exception("search request does not exist."));
             var result = await _sut.CancelSearchRequest("requestId", updateSearchRequestOrdered);
 
             _agencyRequestServiceMock.Verify(x => x.ProcessSearchRequestOrdered(It.IsAny<SearchRequestOrdered>()), Times.Never);
-            Assert.IsInstanceOf(typeof(BadRequestObjectResult), result);
+            Assert.AreEqual(500, ((ObjectResult)result).StatusCode);
         }
 
         [Test]

--- a/app/DynamicsAdapter/DynamicsAdapter.Web.Test/SearchAgency/AgencyRequestService_Update_Test.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web.Test/SearchAgency/AgencyRequestService_Update_Test.cs
@@ -1218,15 +1218,15 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
         }
 
         [Test]
-        public async Task wrong_fileId_searchRequestOrdered_ProcessUpdateSearchRequest_should_return_null()
+        public async Task wrong_fileId_searchRequestOrdered_ProcessUpdateSearchRequest_should_throw_exception()
         {
             Guid guid = Guid.NewGuid();
             _searchRequestServiceMock.Setup(x => x.GetSearchRequest(It.IsAny<string>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult<SSG_SearchRequest>(null));
             SearchRequestOrdered searchRequestOrdered = new SearchRequestOrdered();
-            SSG_SearchRequest ssgSearchRequest = await _sut.ProcessUpdateSearchRequest(searchRequestOrdered);
+            Assert.ThrowsAsync<Exception>(async()=> await _sut.ProcessUpdateSearchRequest(searchRequestOrdered));
             _searchRequestServiceMock.Verify(m => m.CreateNotes(It.IsAny<NotesEntity>(), It.IsAny<CancellationToken>()), Times.Never);
-            Assert.AreEqual(null, ssgSearchRequest);
+
         }
 
         [Test]
@@ -1244,7 +1244,7 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
         }
 
         [Test]
-        public async Task null_searchRequestOrdered_ProcessUpdateSearchRequest_should_return_null()
+        public async Task null_searchRequestOrdered_ProcessUpdateSearchRequest_should_throw_exception()
         {
             _searchRequestServiceMock.Setup(x => x.GetPerson(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
                     .Returns(Task.FromResult<SSG_Person>(new SSG_Person()
@@ -1257,8 +1257,7 @@ namespace DynamicsAdapter.Web.Test.SearchAgency
 
             Guid guid = Guid.NewGuid();
             SearchRequestOrdered searchRequestOrdered = new SearchRequestOrdered { Person = new Person { Agency = new Agency { Code = "FMEP" } } };
-            SSG_SearchRequest ssgSearchRequest = await _sut.ProcessUpdateSearchRequest(searchRequestOrdered);
-            Assert.AreEqual(null, ssgSearchRequest);
+            Assert.ThrowsAsync<Exception>(async () => await _sut.ProcessUpdateSearchRequest(searchRequestOrdered));
         }
 
         [Test]

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/AgencyRequestController.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/AgencyRequestController.cs
@@ -69,7 +69,7 @@ namespace DynamicsAdapter.Web.SearchAgency
                 catch (Exception ex)
                 {
                     SSG_SearchRequest createdSR = _agencyRequestService.GetSSGSearchRequest();
-                    if( createdSR != null)
+                    if (createdSR != null)
                     {
                         await _agencyRequestService.SystemCancelSSGSearchRequest(createdSR);
                     }
@@ -110,17 +110,20 @@ namespace DynamicsAdapter.Web.SearchAgency
                 {
                     updatedSearchRequest = await _agencyRequestService.ProcessUpdateSearchRequest(searchRequestOrdered);
                     if (updatedSearchRequest == null)
-                        return BadRequest(new { Message = $"FileId ( {searchRequestOrdered.SearchRequestKey} ) is invalid." });
+                    {
+                        return StatusCode(StatusCodes.Status500InternalServerError, new { ReasonCode = "error", Message ="error" });
+                    }                
                 }
                 catch (AgencyRequestException ex)
                 {
                     _logger.LogError(ex.Message);
-                    return StatusCode(StatusCodes.Status500InternalServerError, new { ReasonCode = ex.Message, Message = ex.InnerException?.Message });
+                    return BadRequest(new { Message = $"FileId ( {searchRequestOrdered.SearchRequestKey} ) is invalid. {ex.Message}" });
+
                 }
                 catch (Exception ex)
                 {
                     _logger.LogError(ex.Message);
-                    return StatusCode(StatusCodes.Status500InternalServerError, new { ReasonCode = "error", Message = "error" });
+                    return StatusCode(StatusCodes.Status500InternalServerError, new { ReasonCode = "error", Message = ex.Message });
                 }
                 _logger.LogInformation("UpdateSearchRequest successfully");
                 return Ok(BuildSearchRequestSaved_Update(updatedSearchRequest, searchRequestOrdered));

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/AgencyRequestController.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/AgencyRequestController.cs
@@ -73,8 +73,12 @@ namespace DynamicsAdapter.Web.SearchAgency
                     {
                         await _agencyRequestService.SystemCancelSSGSearchRequest(createdSR);
                     }
+                    if( ex is Simple.OData.Client.WebRequestException)
+                    {
+                        _logger.LogError(((Simple.OData.Client.WebRequestException)ex).Response);
+                    }
                     _logger.LogError(ex.Message);
-                    return StatusCode(StatusCodes.Status504GatewayTimeout, new { ReasonCode = ex.Message, Message = ex.InnerException?.Message });
+                    return StatusCode(StatusCodes.Status500InternalServerError, new { ReasonCode = ex.Message, Message = ex.InnerException?.Message });
                 }
             }
         }
@@ -122,6 +126,10 @@ namespace DynamicsAdapter.Web.SearchAgency
                 }
                 catch (Exception ex)
                 {
+                    if (ex is Simple.OData.Client.WebRequestException)
+                    {
+                        _logger.LogError(((Simple.OData.Client.WebRequestException)ex).Response);
+                    }
                     _logger.LogError(ex.Message);
                     return StatusCode(StatusCodes.Status500InternalServerError, new { ReasonCode = "error", Message = ex.Message });
                 }
@@ -157,16 +165,18 @@ namespace DynamicsAdapter.Web.SearchAgency
                 try
                 {
                     cancelledSearchRequest = await _agencyRequestService.ProcessCancelSearchRequest(searchRequestOrdered);
-                    if (cancelledSearchRequest == null)
-                        return BadRequest(new { Message = $"FileId ( {searchRequestOrdered.SearchRequestKey} ) is invalid." });
                 }
                 catch (AgencyRequestException ex)
                 {
                     _logger.LogError(ex.Message);
-                    return StatusCode(StatusCodes.Status500InternalServerError, new { ReasonCode = ex.Message, Message = ex.InnerException?.Message });
+                    return BadRequest(new { Message = $"FileId ( {searchRequestOrdered.SearchRequestKey} ) is invalid. {ex.Message}" });
                 }
                 catch (Exception ex)
                 {
+                    if (ex is Simple.OData.Client.WebRequestException)
+                    {
+                        _logger.LogError(((Simple.OData.Client.WebRequestException)ex).Response);
+                    }
                     _logger.LogError(ex.Message);
                     return StatusCode(StatusCodes.Status500InternalServerError, new { ReasonCode = "error", Message = "error" });
                 }
@@ -214,6 +224,10 @@ namespace DynamicsAdapter.Web.SearchAgency
                 }
                 catch (Exception ex)
                 {
+                    if (ex is Simple.OData.Client.WebRequestException)
+                    {
+                        _logger.LogError(((Simple.OData.Client.WebRequestException)ex).Response);
+                    }
                     _logger.LogError(ex.Message);
                     return StatusCode(StatusCodes.Status504GatewayTimeout, new { ReasonCode = "error", Message = "error" });
                 }

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/AgencyRequestService.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/AgencyRequestService.cs
@@ -94,8 +94,7 @@ namespace DynamicsAdapter.Web.SearchAgency
         {
             var cts = new CancellationTokenSource();
             _cancellationToken = cts.Token;
-            SSG_SearchRequest existedSearchRequest = await VerifySearchRequest(searchRequestOrdered);
-            if (existedSearchRequest == null) return null;
+            await VerifySearchRequest(searchRequestOrdered);
             return await _searchRequestService.CancelSearchRequest(searchRequestOrdered.SearchRequestKey, searchRequestOrdered?.Person?.Agency?.Notes, _cancellationToken);
         }
 

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/AgencyRequestService.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/AgencyRequestService.cs
@@ -238,7 +238,7 @@ namespace DynamicsAdapter.Web.SearchAgency
             SSG_SearchRequest existedSearchRequest = await _searchRequestService.GetSearchRequest(searchRequestOrdered.SearchRequestKey, _cancellationToken);
             if (existedSearchRequest == null)
             {
-                string error = "the updating search request does not exist.";
+                string error = "the search request does not exist.";
                 _logger.LogInformation(error);
                 throw new Exception(error);
             }

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/AgencyRequestService.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/AgencyRequestService.cs
@@ -113,8 +113,9 @@ namespace DynamicsAdapter.Web.SearchAgency
                     m => m.IsPrimary == true);
             if (existedSoughtPerson == null)
             {
-                _logger.LogError("the updating personSought does not exist. something is wrong.");
-                return null;
+                string error = "the updating personSought does not exist. something is wrong.";
+                _logger.LogError(error);
+                throw new Exception(error);
             }
             existedSoughtPerson = await _searchRequestService.GetPerson(existedSoughtPerson.PersonId, _cancellationToken);
             existedSoughtPerson.IsDuplicated = true;
@@ -124,8 +125,9 @@ namespace DynamicsAdapter.Web.SearchAgency
             SearchRequestEntity newSearchRequest = _mapper.Map<SearchRequestEntity>(searchRequestOrdered);
             if (newSearchRequest == null)
             {
-                _logger.LogError("cannot do updating as newSearchRequest is null");
-                return null;
+                string error = "cannot do updating as newSearchRequest is null";
+                _logger.LogError(error);
+                throw new Exception(error);
             }
 
             //update searchRequestEntity
@@ -141,8 +143,9 @@ namespace DynamicsAdapter.Web.SearchAgency
             //update PersonEntity
             if (searchRequestOrdered.Person == null)
             {
-                _logger.LogError("the searchRequestOrdered does not contain Person. The request is wrong.");
-                return null;
+                string error = "the searchRequestOrdered does not contain Person. The request is wrong.";
+                _logger.LogError(error);
+                throw new Exception(error);
             }
             _personSought = searchRequestOrdered.Person;
 
@@ -236,8 +239,9 @@ namespace DynamicsAdapter.Web.SearchAgency
             SSG_SearchRequest existedSearchRequest = await _searchRequestService.GetSearchRequest(searchRequestOrdered.SearchRequestKey, _cancellationToken);
             if (existedSearchRequest == null)
             {
-                _logger.LogInformation("the updating search request does not exist.");
-                return null;
+                string error = "the updating search request does not exist.";
+                _logger.LogInformation(error);
+                throw new Exception(error);
             }
             if (existedSearchRequest.StatusCode == SearchRequestStatusCode.SearchRequestCancelled.Value)
             {

--- a/app/SearchApi/SearchRequest.Adaptor.Test/Notifier/SearchRequestNotifierTest.cs
+++ b/app/SearchApi/SearchRequest.Adaptor.Test/Notifier/SearchRequestNotifierTest.cs
@@ -163,26 +163,17 @@ namespace SearchRequest.Adaptor.Test.Notifier
 
 
         [Test]
-        public async Task NotifySearchRequestEventAsync_should_publish_failed_if_invalid_url_setting()
+        public async Task NotifySearchRequestEventAsync_should_throw_exception_if_invalid_url_setting()
         {
             _searchRequestOptionsMock.Setup(x => x.Value).Returns(
                 new SearchRequestAdaptorOptions().AddWebHook("test", "invalidUrl"));
 
             _sut = new WebHookSearchRequestNotifier(_httpClient, _searchRequestOptionsMock.Object, _loggerMock.Object, _searchRquestEventPublisherMock.Object);
+            Assert.ThrowsAsync<Exception>(
+                async()=>
             await _sut.NotifySearchRequestEventAsync(
                     _fakeSearchRequestOrdered.RequestId,
-                    _fakeSearchRequestOrdered, CancellationToken.None);
-
-            _httpHandlerMock.Protected().Verify(
-                    "SendAsync",
-                    Times.Exactly(0),
-                    ItExpr.IsAny<HttpRequestMessage>(),
-                    ItExpr.IsAny<CancellationToken>()
-                );
-
-            _searchRquestEventPublisherMock.Verify(
-                x => x.PublishSearchRequestFailed(
-                It.IsAny<SearchRequestEvent>(), It.IsAny<string>()), Times.Once);
+                    _fakeSearchRequestOrdered, CancellationToken.None));
         }
 
 
@@ -224,7 +215,7 @@ namespace SearchRequest.Adaptor.Test.Notifier
         }
 
         [Test]
-        public async Task NotifySearchRequestEventAsync_should_publish_failed_if_http_throw_exception()
+        public async Task NotifySearchRequestEventAsync_should_throw_exception_if_http_throw_exception()
         {
             _searchRequestOptionsMock.Setup(x => x.Value).Returns(
                    new SearchRequestAdaptorOptions().AddWebHook("test", "http://test.org"));
@@ -237,20 +228,11 @@ namespace SearchRequest.Adaptor.Test.Notifier
                 ).Throws(new Exception("mock http throw exception"));
 
             _sut = new WebHookSearchRequestNotifier(_httpClient, _searchRequestOptionsMock.Object, _loggerMock.Object, _searchRquestEventPublisherMock.Object);
+            Assert.ThrowsAsync<Exception>(async()=>
             await _sut.NotifySearchRequestEventAsync(
                      _fakeSearchRequestOrdered.RequestId,
-                     _fakeSearchRequestOrdered, CancellationToken.None);
+                     _fakeSearchRequestOrdered, CancellationToken.None));
 
-            _httpHandlerMock.Protected().Verify(
-                    "SendAsync",
-                    Times.Exactly(1),
-                    ItExpr.IsAny<HttpRequestMessage>(),
-                    ItExpr.IsAny<CancellationToken>()
-                );
-
-            _searchRquestEventPublisherMock.Verify(
-                x => x.PublishSearchRequestFailed(
-                It.IsAny<SearchRequestEvent>(), It.IsAny<string>()), Times.Once);
         }
 
         [Test]
@@ -264,37 +246,7 @@ namespace SearchRequest.Adaptor.Test.Notifier
 
         }
 
-        //no failed event, FMEP does not accept it.
-        //[Test]
-        //public void NotifySearchRequestEventAsync_should_not_publish_failed_if_http_throw_exception_and_not_reach_maxRetries()
-        //{
-        //    _searchRequestOptionsMock.Setup(x => x.Value).Returns(
-        //           new SearchRequestAdaptorOptions().AddWebHook("test", "http://test.org"));
-        //    _httpHandlerMock
-        //        .Protected()
-        //        .Setup<Task<HttpResponseMessage>>(
-        //            "SendAsync",
-        //            ItExpr.IsAny<HttpRequestMessage>(),
-        //            ItExpr.IsAny<CancellationToken>()
-        //        ).Throws(new Exception("mock http throw exception"));
-
-        //    _sut = new WebHookSearchRequestNotifier(_httpClient, _searchRequestOptionsMock.Object, _loggerMock.Object, _searchRquestEventPublisherMock.Object);
-        //    Assert.ThrowsAsync<Exception>(()=> _sut.NotifySearchRequestEventAsync(
-        //             _fakeSearchRequestOrdered.RequestId,
-        //             _fakeSearchRequestOrdered, CancellationToken.None,0,3));
-
-        //    _httpHandlerMock.Protected().Verify(
-        //            "SendAsync",
-        //            Times.Exactly(1),
-        //            ItExpr.IsAny<HttpRequestMessage>(),
-        //            ItExpr.IsAny<CancellationToken>()
-        //        );
-
-        //    _searchRquestEventPublisherMock.Verify(
-        //        x => x.PublishSearchRequestFailed(
-        //        It.IsAny<SearchRequestEvent>(), It.IsAny<string>()), Times.Never);
-        //}
-
+ 
         [Test]
         public async Task NotifySearchRequestEventAsync_with_Ack_should_send_httpRequest_to_one_subscribers()
         {

--- a/app/SearchApi/SearchRequest.Adaptor/Notifier/SearchRequestNotifier.cs
+++ b/app/SearchApi/SearchRequest.Adaptor/Notifier/SearchRequestNotifier.cs
@@ -82,9 +82,6 @@ namespace SearchRequestAdaptor.Notifier
                 {
                     _logger.LogWarning(
                         $"The webHook {webHookName} notification uri is not established or is not an absolute Uri for {webHook.Name}. Set the WebHook.Uri value on SearchApi.WebHooks settings.");
-                    //await _searchRequestEventPublisher.PublishSearchRequestFailed(
-                    //   searchRequestOrdered, "notification uri is not established or is not an absolute Uri."
-                    //    );
                     throw new Exception($"The webHook {webHookName} notification uri is not established or is not an absolute Uri for {webHook.Name}.");
                 }
 

--- a/app/SearchApi/SearchRequest.Adaptor/Notifier/SearchRequestNotifier.cs
+++ b/app/SearchApi/SearchRequest.Adaptor/Notifier/SearchRequestNotifier.cs
@@ -34,6 +34,7 @@ namespace SearchRequestAdaptor.Notifier
         public WebHookSearchRequestNotifier(HttpClient httpClient, IOptions<SearchRequestAdaptorOptions> searchRequestOptions, ILogger<WebHookSearchRequestNotifier> logger, ISearchRequestEventPublisher searchRequestEventPublisher)
         {
             _httpClient = httpClient;
+            _httpClient.Timeout = TimeSpan.FromMinutes(3);
             _logger = logger;
             _searchRequestOptions = searchRequestOptions.Value;
             _searchRequestEventPublisher = searchRequestEventPublisher;
@@ -81,10 +82,10 @@ namespace SearchRequestAdaptor.Notifier
                 {
                     _logger.LogWarning(
                         $"The webHook {webHookName} notification uri is not established or is not an absolute Uri for {webHook.Name}. Set the WebHook.Uri value on SearchApi.WebHooks settings.");
-                    await _searchRequestEventPublisher.PublishSearchRequestFailed(
-                       searchRequestOrdered, "notification uri is not established or is not an absolute Uri."
-                        );
-                    return;
+                    //await _searchRequestEventPublisher.PublishSearchRequestFailed(
+                    //   searchRequestOrdered, "notification uri is not established or is not an absolute Uri."
+                    //    );
+                    throw new Exception($"The webHook {webHookName} notification uri is not established or is not an absolute Uri for {webHook.Name}.");
                 }
 
                 using var request = new HttpRequestMessage();
@@ -105,19 +106,12 @@ namespace SearchRequestAdaptor.Notifier
 
                     if (!response.IsSuccessStatusCode)
                     {
-                        if (response.StatusCode == System.Net.HttpStatusCode.InternalServerError)
+                        if (response.StatusCode == System.Net.HttpStatusCode.InternalServerError || response.StatusCode==System.Net.HttpStatusCode.GatewayTimeout)
                         {
                             string reason = await response.Content.ReadAsStringAsync();
-                            RejectReason reasonObj = JsonConvert.DeserializeObject<RejectReason>(reason);
                             _logger.LogError(
-                                $"The webHook {webHookName} notification has not executed status {eventName} successfully for {webHook.Name} webHook. The error code is {response.StatusCode.GetHashCode()}.");
-                            await _searchRequestEventPublisher.PublishSearchRequestRejected(
-                                    searchRequestOrdered,
-                                    new List<ValidationResult>()
-                                    {
-                                    new ValidationResultData(){ PropertyName=reasonObj.ReasonCode, ErrorMessage=reasonObj.Message }
-                                    });
-                            return;
+                                $"The webHook {webHookName} notification has not executed status {eventName} successfully for {webHook.Name} webHook. The error code is {response.StatusCode.GetHashCode()}.Reason is {reason}.");
+                            throw(new Exception($"The webHook {webHookName} notification has not executed status {eventName} successfully for {webHook.Name} webHook. The error code is {response.StatusCode.GetHashCode()}."));
                         }
                         else if (response.StatusCode == System.Net.HttpStatusCode.BadRequest)
                         {
@@ -129,23 +123,15 @@ namespace SearchRequestAdaptor.Notifier
                                     });
                             return;
                         }
-                        else if(response.StatusCode == System.Net.HttpStatusCode.GatewayTimeout)
-                        {
-                            if (retryTimes >= maxRetryTimes)
-                            {
-                                _logger.LogError($"Gateway Timeout, already retry max retry times.");
-                                return;
-                            }
-                            _logger.LogError($"Message Failed { response.StatusCode}, {response.Content.ReadAsStringAsync()}");
-                            throw new Exception($"Message Failed {response.StatusCode}, {response.Content.ReadAsStringAsync()}");
-                        }
+
+                        throw new Exception($"Message Failed {response.StatusCode}, {response.Content.ReadAsStringAsync()}");
                     }
 
                     _logger.LogInformation("get response successfully from webhook.");
                     string responseContent = await response.Content.ReadAsStringAsync();
                     var saved = JsonConvert.DeserializeObject<SearchRequestSavedEvent>(responseContent);
 
-                    //for the new action will get Notification, only failed or rejected are got published.
+                    //for the new action will get Notification, only rejected are got published.
                     //for the update action, fmep needs notified and notification from dynamics.
                     if (saved.Action != RequestAction.NEW)
                     {
@@ -156,14 +142,8 @@ namespace SearchRequestAdaptor.Notifier
                 }
                 catch (Exception exception)
                 {
-                    if (retryTimes >= maxRetryTimes)
-                    {
-                        await _searchRequestEventPublisher.PublishSearchRequestFailed(searchRequestOrdered, exception.Message);
-                        _logger.LogError($"The webHook {webHookName} notification failed for {eventName} for {webHook.Name} webHook. [{exception.Message}]");
-                        return;
-                    }
-                    return;
-                    //throw exception;
+                    _logger.LogError(exception.Message);
+                    throw exception;
                 }
             }
         }

--- a/app/SearchApi/SearchRequest.Adaptor/Startup.cs
+++ b/app/SearchApi/SearchRequest.Adaptor/Startup.cs
@@ -206,11 +206,11 @@ namespace SearchRequestAdaptor
                     {
 
                         e.UseRateLimit(1, TimeSpan.FromSeconds(5));
-                        e.UseMessageRetry(r=> {
-                            r.Ignore<ArgumentNullException>();
-                            r.Ignore<InvalidOperationException>();
-                            r.Interval(retryConfiguration.RetryTimes, TimeSpan.FromMinutes(retryConfiguration.RetryInterval));
-                        });
+                        //e.UseMessageRetry(r=> {
+                        //    r.Ignore<ArgumentNullException>();
+                        //    r.Ignore<InvalidOperationException>();
+                        //    r.Interval(retryConfiguration.RetryTimes, TimeSpan.FromMinutes(retryConfiguration.RetryInterval));
+                        //});
 
                         e.Consumer(() =>
                             new SearchRequestOrderedConsumer(
@@ -225,11 +225,11 @@ namespace SearchRequestAdaptor
                     {
 
                         e.UseRateLimit(1, TimeSpan.FromSeconds(5));
-                        e.UseMessageRetry(r => {
-                            r.Ignore<ArgumentNullException>();
-                            r.Ignore<InvalidOperationException>();
-                            r.Interval(retryConfiguration.RetryTimes, TimeSpan.FromMinutes(retryConfiguration.RetryInterval));
-                        });
+                        //e.UseMessageRetry(r => {
+                        //    r.Ignore<ArgumentNullException>();
+                        //    r.Ignore<InvalidOperationException>();
+                        //    r.Interval(retryConfiguration.RetryTimes, TimeSpan.FromMinutes(retryConfiguration.RetryInterval));
+                        //});
 
                         e.Consumer(() =>
                             new NotificationAcknowledgedConsumer(


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

- FAMS3-3711(autosearch missing events-completed, accepted and failed. - the event key is deleted before event come back.)
- FAMS3-3680(duplicate SR gets created for the same search request from FMEP. )

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [X] New and existing unit tests pass locally with my changes
