### PR TITLE
FAMS3-4222: Tax Income Info - OT xml processing should not merge Person Sought

### DIFF
--- a/app/DynamicsAdapter/DynamicsAdapter.Web.Test/PersonSearch/PersonSearchControllerTest.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web.Test/PersonSearch/PersonSearchControllerTest.cs
@@ -35,7 +35,7 @@ namespace DynamicsAdapter.Web.Test.PersonSearch
         private Mock<ILogger<PersonSearchController>> _loggerMock ;
         private Mock<ISearchResultService> _searchResultServiceMock;
         private Mock<ISearchApiRequestService> _searchApiRequestServiceMock;
-        private Mock<IDataPartnerService> _dataPartnerServiceMock; 
+        private Mock<IDataPartnerService> _dataPartnerServiceMock;
         private Mock<ISearchRequestRegister> _registerMock;
         private PersonSearchCompleted _fakePersonCompletedEvent;
         private PersonSearchAccepted _fakePersonAcceptedEvent;
@@ -236,6 +236,9 @@ namespace DynamicsAdapter.Web.Test.PersonSearch
             _mapper.Setup(m => m.Map<SSG_SearchApiEvent>(It.IsAny<PersonSearchSubmitted>()))
                                 .Returns(_fakeSearchApiEvent);
 
+            _mapper.Setup(m => m.Map<SSG_SearchApiEvent>(It.IsAny<PersonSearchInformation>()))
+                                .Returns(_fakeSearchApiEvent);
+
             _mapper.Setup(m => m.Map<IdentifierEntity>(It.IsAny<PersonalIdentifier>()))
                                .Returns(_fakePersoneIdentifier);
 
@@ -297,6 +300,14 @@ namespace DynamicsAdapter.Web.Test.PersonSearch
                 .Returns(Task.FromResult(_fakeSearchApiRequest));
             _registerMock.Setup(x => x.GetSearchApiRequest(It.Is<string>(m => m == _searchRequestKeySearchNotComplete)))
                 .Returns(Task.FromResult(_fakeSearchApiRequest));
+
+            // Setup for the exception search request key
+            var exceptionSearchApiRequest = new SSG_SearchApiRequest()
+            {
+                SearchApiRequestId = _exceptionGuid
+            };
+            _registerMock.Setup(x => x.GetSearchApiRequest(It.Is<string>(m => m == _exceptionSearchRequestKey)))
+                .Returns(Task.FromResult(exceptionSearchApiRequest));
 
             _registerMock.Setup(x => x.DataPartnerSearchIsComplete(It.Is<string>(m => m == _searchRequestKey)))
             .Returns(Task.FromResult(true));
@@ -447,6 +458,13 @@ namespace DynamicsAdapter.Web.Test.PersonSearch
             Assert.IsInstanceOf(typeof(OkResult), result);
         }
 
+        [Test]
+        public async Task With_exception_information_event_it_should_return_badrequest()
+        {
+            var result = await _sut.InformationReceived(_exceptionSearchRequestKey, _fakePersonInformationEvent);
+            Assert.IsInstanceOf(typeof(BadRequestResult), result);
+        }
+
 
 
         [Test]
@@ -465,7 +483,7 @@ namespace DynamicsAdapter.Web.Test.PersonSearch
                 .Returns(Task.FromResult<SSG_SearchApiRequest>(null));
             _searchResultServiceMock.Setup(x => x.GetSearchRequest(It.Is<string>(m => m == "111111"),
                 It.IsAny<CancellationToken>()))
-                .Returns(Task.FromResult<SSG_SearchRequest>(new SSG_SearchRequest() { 
+                .Returns(Task.FromResult<SSG_SearchRequest>(new SSG_SearchRequest() {
                     SearchRequestId = srId,
                     JCAFirstName="JCAFirstName",
                     JCALastName="JCALastName",

--- a/app/DynamicsAdapter/DynamicsAdapter.Web.Test/PersonSearch/SearchResultServiceTest.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web.Test/PersonSearch/SearchResultServiceTest.cs
@@ -398,7 +398,7 @@ namespace DynamicsAdapter.Web.Test.PersonSearch
 
             _searchRequestServiceMock.Setup(x => x.CreateIdentifier(It.IsAny<IdentifierEntity>(), It.IsAny<CancellationToken>()))
                 .Returns(Task.FromResult<SSG_Identifier>(new SSG_Identifier()
-                {                    
+                {
                 }));
 
             _searchRequestServiceMock.Setup(x => x.CreateAddress(It.Is<AddressEntity>(x => x.SearchRequest.SearchRequestId == validRequestId), It.IsAny<CancellationToken>()))
@@ -498,10 +498,10 @@ namespace DynamicsAdapter.Web.Test.PersonSearch
 
             _searchRequestServiceMock.Setup(x => x.CreateTransaction(It.IsAny<SSG_SearchRequestResultTransaction>(), It.IsAny<CancellationToken>()))
             .Returns(Task.FromResult<SSG_SearchRequestResultTransaction>(new SSG_SearchRequestResultTransaction()
-            {                
+            {
             }));
 
-            _sut = new SearchResultService(_searchRequestServiceMock.Object, new NullLoggerFactory(), _mapper.Object);
+            _sut = new SearchResultService(_searchRequestServiceMock.Object, _loggerMock.Object, _mapper.Object);
 
         }
 

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/Mapping/Converters.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/Mapping/Converters.cs
@@ -601,7 +601,7 @@ namespace DynamicsAdapter.Web.Mapping
                         taxIncomeInformation.FirstName = names[0];
                         taxIncomeInformation.LastName = names[1];
                     }
-                    taxIncomeInformation.Description = tax.Description ?? tax.TaxCode ?? string.Empty;
+                    taxIncomeInformation.Description = tax.Description ?? (!string.IsNullOrEmpty(tax.TaxCode) ? tax.TaxCode : string.Empty);
                     toReturn.Add(taxIncomeInformation);
                 }
             }

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/Mapping/Converters.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/Mapping/Converters.cs
@@ -371,7 +371,7 @@ namespace DynamicsAdapter.Web.Mapping
 
         }
     }
-    
+
 
     public class SocailMediaTypeResponseConverter : IValueConverter<int?, string>
     {
@@ -393,7 +393,7 @@ namespace DynamicsAdapter.Web.Mapping
                 return $"Auto search processing completed successfully. 0 Matched Persons found.";
             var matchedPersons = sourceMember.MatchedPersons;
 
-            
+
             if (!string.IsNullOrEmpty(sourceMember.Message))
                 strbuilder.Append($"Auto search processing completed successfully. {sourceMember.Message}. {matchedPersons.Count()} Matched Persons found.\n");
             else
@@ -403,8 +403,8 @@ namespace DynamicsAdapter.Web.Mapping
             int i = 1;
             foreach (PersonFound p in matchedPersons)
             {
-           
-               
+
+
                 strbuilder.Append($"For Matched Person {i} : ");
                 if (p.SourcePersonalIdentifier != null)
                     strbuilder.Append($" Source ID:- {p.SourcePersonalIdentifier.Type}/{p.SourcePersonalIdentifier.Value} - ");
@@ -588,14 +588,20 @@ namespace DynamicsAdapter.Web.Mapping
                     taxIncomeInformation.EmploymentIncomeT4Amount = tax.EmploymentIncomeT4Amount;
                     taxIncomeInformation.JcaCode = tax.JCACode;
                     taxIncomeInformation.TaxTraceStatusText = tax.TaxTraceStatusText;
-                    taxIncomeInformation.TaxCode = JsonConvert.DeserializeObject<TaxCode>(tax.TaxCode);
+
+                    // Handle null TaxCode
+                    if (!string.IsNullOrEmpty(tax.TaxCode))
+                    {
+                        taxIncomeInformation.TaxCode = JsonConvert.DeserializeObject<TaxCode>(tax.TaxCode);
+                    }
+
                     var names = tax.FullName?.Split(' ');
                     if (names?.Length == 2)
                     {
                         taxIncomeInformation.FirstName = names[0];
                         taxIncomeInformation.LastName = names[1];
                     }
-                    taxIncomeInformation.Description = tax.Description ?? tax.TaxCode;
+                    taxIncomeInformation.Description = tax.Description ?? tax.TaxCode ?? string.Empty;
                     toReturn.Add(taxIncomeInformation);
                 }
             }

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/PersonSearch/SearchResultService.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/PersonSearch/SearchResultService.cs
@@ -32,8 +32,8 @@ namespace DynamicsAdapter.Web.PersonSearch
     public interface ISearchResultService
     {
         Task<bool> ProcessPersonFound(
-            Person person, 
-            ProviderProfile providerProfile, 
+            Person person,
+            ProviderProfile providerProfile,
             SSG_SearchRequest searchRequest,
             Guid? searchApiRequestId,
             CancellationToken cancellationToken,
@@ -70,34 +70,48 @@ namespace DynamicsAdapter.Web.PersonSearch
         }
 
         public async Task<bool> ProcessPersonFound(
-            Person person, 
-            ProviderProfile providerProfile, 
-            SSG_SearchRequest searchRequest, 
-            Guid? searchApiRequestId, 
-            CancellationToken cancellationToken, 
+            Person person,
+            ProviderProfile providerProfile,
+            SSG_SearchRequest searchRequest,
+            Guid? searchApiRequestId,
+            CancellationToken cancellationToken,
             SSG_Identifier sourceIdentifier = null)
         {
             if (person == null) return true;
 
-            if (person.TaxIncomeInformations != null && person.TaxIncomeInformations.Any())
-            {
-                var taxCodes = await _searchRequestService.GetTaxCodes(cancellationToken);
-                foreach (var taxIncomeInformation in person.TaxIncomeInformations)
-                {
-                    taxIncomeInformation.Description = taxCodes
-                        .FirstOrDefault(x => x.TaxCode == taxIncomeInformation.TaxCode.Code)?
-                        .Description;
-                }
-                person.MiddleName = person.TaxIncomeInformations.FirstOrDefault().MiddleName;
-                person.OtherName = person.TaxIncomeInformations.FirstOrDefault().OtherName;
-                person.FirstName = person.TaxIncomeInformations.FirstOrDefault().FirstName;// ?? person.FirstName;
-                person.LastName = person.TaxIncomeInformations.FirstOrDefault().LastName;// ?? person.LastName;
-                person.DateOfBirth = person.TaxIncomeInformations.FirstOrDefault().DateOfBirth;// ?? person.DateOfBirth;
-                person.Date1 = DateTime.Now;
-            }
-            person.SuppliedBySystem = Constants.JcaSystem;
-            _foundPerson = person;
+            bool hasTaxInfo = person.TaxIncomeInformations != null && person.TaxIncomeInformations.Any();
+
+            // STEP 1: Always process the person details
+            _logger.LogInformation("Processing person details");
             
+            Person personDetailsClone = new Person
+            {
+                FirstName = person.FirstName,
+                LastName = person.LastName,
+                MiddleName = person.MiddleName,
+                OtherName = null,
+                DateOfBirth = person.DateOfBirth,
+                Gender = person.Gender,
+                Addresses = person.Addresses,
+                Phones = person.Phones,
+                Emails = person.Emails,
+                Employments = person.Employments,
+                Identifiers = person.Identifiers,
+                Names = person.Names,
+                RelatedPersons = person.RelatedPersons,
+                BankInfos = person.BankInfos,
+                Vehicles = person.Vehicles,
+                OtherAssets = person.OtherAssets,
+                CompensationClaims = person.CompensationClaims,
+                InsuranceClaims = person.InsuranceClaims,
+                CautionFlag = person.CautionFlag,
+                CautionReason = person.CautionReason,
+                CautionNotes = person.CautionNotes,
+                SuppliedBySystem = Constants.JcaSystem,
+            };
+
+            // Process and upload the person details
+            _foundPerson = personDetailsClone;
             _providerDynamicsID = providerProfile.DynamicsID();
             _searchRequest = searchRequest;
             _sourceIdentifier = sourceIdentifier;
@@ -105,34 +119,50 @@ namespace DynamicsAdapter.Web.PersonSearch
             _cancellationToken = cancellationToken;
 
             _returnedPerson = await UploadPerson();
-
             await UploadSafetyConcern();
-
-            await UploadIdentifiers( );
-
+            await UploadIdentifiers();
             await UploadAddresses();
-
-            await UploadTaxIncomeInformations(cancellationToken);
-
             await UploadPhoneNumbers();
-
-            await UploadNames( );
-
-            await UploadEmployment( );
-
+            await UploadNames();
+            await UploadEmployment();
             await UploadRelatedPersons();
-
             await UploadBankInfos();
-
             await UploadVehicles();
-
             await UploadOtherAssets();
-
             await UploadCompensationClaims();
-
             await UploadInsuranceClaims();
-
             await UploadEmails();
+
+            // STEP 2: If we have tax information, process it as a separate record
+            if (hasTaxInfo)
+            {
+                // Process tax codes
+                var taxCodes = await _searchRequestService.GetTaxCodes(cancellationToken);
+                foreach (var taxIncomeInformation in person.TaxIncomeInformations)
+                {
+                    taxIncomeInformation.Description = taxCodes
+                        .FirstOrDefault(x => x.TaxCode == taxIncomeInformation.TaxCode.Code)?
+                        .Description;
+                }
+
+                // Create a new person object for tax information
+                Person taxPerson = new Person
+                {
+                    MiddleName = person.TaxIncomeInformations.FirstOrDefault().MiddleName,
+                    OtherName = person.TaxIncomeInformations.FirstOrDefault().OtherName,
+                    FirstName = person.TaxIncomeInformations.FirstOrDefault().FirstName,
+                    LastName = person.TaxIncomeInformations.FirstOrDefault().LastName,
+                    DateOfBirth = person.TaxIncomeInformations.FirstOrDefault().DateOfBirth,
+                    Date1 = DateTime.Now,
+                    SuppliedBySystem = Constants.JcaSystem,
+                    TaxIncomeInformations = person.TaxIncomeInformations
+                };
+
+                // Process and upload the tax information
+                _foundPerson = taxPerson;
+                _returnedPerson = await UploadPerson();
+                await UploadTaxIncomeInformations(cancellationToken);
+            }
 
             return true;
         }
@@ -196,8 +226,8 @@ namespace DynamicsAdapter.Web.PersonSearch
         private async Task<bool> UploadSafetyConcern()
         {
             if (string.IsNullOrEmpty(_foundPerson.CautionFlag)) return false;
-            try 
-            { 
+            try
+            {
                 SafetyConcernEntity entity = _mapper.Map<SafetyConcernEntity>(_foundPerson);
                 entity.SearchRequest = _searchRequest;
                 entity.InformationSource = _providerDynamicsID;
@@ -268,7 +298,7 @@ namespace DynamicsAdapter.Web.PersonSearch
 
         private async Task<bool> UploadTaxIncomeInformations(CancellationToken cancellationToken)
         {
-            if (_foundPerson.TaxIncomeInformations == null) 
+            if (_foundPerson.TaxIncomeInformations == null)
                 return true;
 
             try
@@ -660,13 +690,13 @@ namespace DynamicsAdapter.Web.PersonSearch
                 var properties = new Dictionary<string, object>();
                 properties.Add("AbsoluteUri", webRequestException.RequestUri?.AbsoluteUri);
                 properties.Add("Response", webRequestException.Response);
-                using (_logger.BeginScope(properties)) 
+                using (_logger.BeginScope(properties))
                 {
                     _logger.LogError(ex.ToString());
                     _logger.LogError(ex.Message);
                     _logger.LogError(ex.StackTrace);
                 } ;
-                
+
             }
             else
             {
@@ -677,3 +707,4 @@ namespace DynamicsAdapter.Web.PersonSearch
         }
     }
 }
+

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/PersonSearch/SearchResultService.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/PersonSearch/SearchResultService.cs
@@ -179,7 +179,7 @@ namespace DynamicsAdapter.Web.PersonSearch
 
         private async Task<bool> CreateResultTransaction(DynamicsEntity o)
         {
-            if (_sourceIdentifier != null)
+            if (_sourceIdentifier != null && _searchRequest != null)
             {
                 SSG_SearchRequestResultTransaction trans = new SSG_SearchRequestResultTransaction()
                 {
@@ -218,6 +218,12 @@ namespace DynamicsAdapter.Web.PersonSearch
         }
         private async Task<SSG_Person> UploadPerson()
         {
+            if (_searchRequest == null)
+            {
+                _logger.LogWarning("SearchRequest is null. Cannot upload person.");
+                return null;
+            }
+
             _logger.LogDebug($"Attempting to create the found person record for SearchRequest[{_searchRequest.SearchRequestId}]");
             PersonEntity ssg_person = _mapper.Map<PersonEntity>(_foundPerson);
             ssg_person.SearchRequest = _searchRequest;

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/PersonSearch/SearchResultService.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/PersonSearch/SearchResultService.cs
@@ -57,9 +57,14 @@ namespace DynamicsAdapter.Web.PersonSearch
         private CancellationToken _cancellationToken;
 
         public SearchResultService(ISearchRequestService searchRequestService, ILoggerFactory loggerFactory, IMapper mapper)
+            : this(searchRequestService, loggerFactory.CreateLogger<SearchResultService>(), mapper)
+        {
+        }
+
+        public SearchResultService(ISearchRequestService searchRequestService, ILogger<SearchResultService> logger, IMapper mapper)
         {
             _searchRequestService = searchRequestService;
-            _logger = loggerFactory.CreateLogger<SearchResultService>();
+            _logger = logger;
             _mapper = mapper;
             _returnedPerson = null;
             _sourceIdentifier = null;
@@ -83,7 +88,7 @@ namespace DynamicsAdapter.Web.PersonSearch
 
             // STEP 1: Always process the person details
             _logger.LogInformation("Processing person details");
-            
+
             Person personDetailsClone = new Person
             {
                 FirstName = person.FirstName,
@@ -218,8 +223,17 @@ namespace DynamicsAdapter.Web.PersonSearch
             ssg_person.SearchRequest = _searchRequest;
             ssg_person.InformationSource = _providerDynamicsID;
             SSG_Person returnedPerson = await _searchRequestService.SavePerson(ssg_person, _cancellationToken);
-            await CreateResultTransaction(returnedPerson);
-            _logger.LogInformation($"Successfully created person {returnedPerson.PersonId}.");
+
+            if (returnedPerson != null)
+            {
+                await CreateResultTransaction(returnedPerson);
+                _logger.LogInformation($"Successfully created person {returnedPerson.PersonId}.");
+            }
+            else
+            {
+                _logger.LogWarning("SavePerson returned null.");
+            }
+
             return returnedPerson;
         }
 


### PR DESCRIPTION


# Description

This PR includes the following proposed change(s):
- Processing XML files with tax information: generate JCA person details and JCA tax info details:
![image](https://github.com/user-attachments/assets/de9d6e1c-13da-4f23-b522-857ad8a4da35)

- Processing XML files with no tax info: generate only JCA person details:
![image](https://github.com/user-attachments/assets/ef3f3844-33b5-4746-a762-513ebf66acd5)


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?
1.- Request to client for XML files with/without tax information.
2.- Connect to FAMS3 Test on OCP and retrieve the following commands:
```
GET JCA_CtrlCode_ZB61Z4
GET JCA_008819_00012402_PersonSought
GET dyna_008819_00012402
```
3.- Setup your local to point to Dynamics on Test
4.- Set local Redis with the data retrieved from Test
5.- Update FileWatcherJob to read XML file
6.- Run SearchApi, DynamicsAdapter and FileAdapter
7.- Check fileAdapter is sending message to PersonSearchCompletedJCA_queue in order to be picked by SearchApi and start the process.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
