### PR TITLE
Downgrade ubuntu to original version

### DIFF
--- a/.github/workflows/main_promoteimage.yml
+++ b/.github/workflows/main_promoteimage.yml
@@ -22,7 +22,7 @@ on:
         required: true
 jobs:
   oc-image-tagging:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     environment: ${{ github.event.inputs.imageTargetEnv }}
     steps:
       - name: Git Checkout


### PR DESCRIPTION
-Downgrade ubuntu to original version - Ubuntu-latest points to Ubuntu 22.04 no longer include .NET Core 3.1 pre-installed. Issues in compatbility with .NET Core 3.1
-Ubuntu-20.04 is older and still compatible with .NET Core 3.1 and its dependencies, so builds and restores work as expected.

# Description

This PR includes the following proposed change(s):

- {List all the changes, if possible add the jira ticket #}

## Type of change

- [ X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
