### PR TITLE
FAMS3-4276: SearchRequest Redis Bug Fix

### DIFF
--- a/app/.csharpierrc
+++ b/app/.csharpierrc
@@ -1,0 +1,6 @@
+{
+  "printWidth": 140,
+  "useTabs": false,
+  "tabWidth": 4,
+  "endOfLine": "lf"
+}

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/Register/SearchRequestRegister.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/Register/SearchRequestRegister.cs
@@ -276,14 +276,38 @@ namespace DynamicsAdapter.Web.Register
             return true;
         }
 
+        /// <summary>
+        /// Checks if the data partner search is complete for the given search request key.
+        /// </summary>
+        /// <param name="searchRequestKey"></param>
+        /// <returns></returns>
         public async Task<bool> DataPartnerSearchIsComplete(string searchRequestKey)
         {
+            _logger.LogInformation($"DataPartnerSearchIsComplete - Fetching cached value for search key: {searchRequestKey}");
+
             string data = await _cache.GetString($"{searchRequestKey}");
 
-            _logger.LogDebug($"DataPartnerSearchIsComplete : {data}");
-            if (string.IsNullOrEmpty(data)) return true;
-            IEnumerable<JToken> tokens = JObject.Parse(data).SelectTokens("$.DataPartners[?(@.Completed == false)]");
-            return !tokens.Any();
+            _logger.LogDebug($"DataPartnerSearchIsComplete - Cached data: {data}");
+
+            if (string.IsNullOrEmpty(data))
+            {
+                _logger.LogWarning(
+                    $"DataPartnerSearchIsComplete - No data found in cache for searchRequestKey: {searchRequestKey}. Returning true."
+                );
+
+                return true;
+            }
+
+            // Find all DataPartners where Completed is false
+            IEnumerable<JToken> incompleteRecords = JObject.Parse(data).SelectTokens("$.DataPartners[?(@.Completed == false)]");
+            var incompleteCount = incompleteRecords.Count();
+
+            _logger.LogInformation(
+                $"DataPartnerSearchIsComplete - incompleteCount: {incompleteCount}. searchRequestKey: {searchRequestKey}."
+            );
+
+            // Return true if all DataPartners have Completed = true, otherwise return false
+            return incompleteCount == 0;
         }
 
         public async Task<bool> RegisterResponseApiCall(SearchResponseReady ready)

--- a/app/SearchApi/BcGov.Fams3.Redis.Test/CacheServiceTest.cs
+++ b/app/SearchApi/BcGov.Fams3.Redis.Test/CacheServiceTest.cs
@@ -103,9 +103,8 @@ namespace BcGov.Fams3.Redis.Test
             _mockRedisDB.Setup(x => x.GetAsync<string>("key", default)).Returns(Task.FromResult("data"));
             //_stackRedisCacheClient.Db0.GetAsync<string>(key)
             _loggerMock = new Mock<ILogger<CacheService>>();
-         
-            _sut = new CacheService(_distributedCacheMock.Object, _stackRedisCacheClientMock.Object);
 
+            _sut = new CacheService(_distributedCacheMock.Object, _stackRedisCacheClientMock.Object, _loggerMock.Object);
         }
 
         [Test]

--- a/app/SearchApi/BcGov.Fams3.Redis/ICacheService.cs
+++ b/app/SearchApi/BcGov.Fams3.Redis/ICacheService.cs
@@ -1,6 +1,7 @@
 ﻿
 using BcGov.Fams3.Redis.Model;
 using Microsoft.Extensions.Caching.Distributed;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using StackExchange.Redis;
 using StackExchange.Redis.Extensions.Core.Abstractions;
@@ -34,12 +35,13 @@ namespace BcGov.Fams3.Redis
     {
         private readonly IDistributedCache _distributedCache;
         private readonly IRedisCacheClient _stackRedisCacheClient;
+        private readonly ILogger<CacheService> _logger;
 
-        public CacheService(IDistributedCache distributedCache, IRedisCacheClient stackRedisCacheClient)
+        public CacheService(IDistributedCache distributedCache, IRedisCacheClient stackRedisCacheClient, ILogger<CacheService> logger)
         {
             _distributedCache = distributedCache;
             _stackRedisCacheClient = stackRedisCacheClient;
-            
+            _logger = logger;
         }
 
         public async Task SaveRequest(SearchRequest searchRequest)
@@ -143,36 +145,94 @@ namespace BcGov.Fams3.Redis
 
         }
 
-        public async Task<int> UpdateDataPartnerCompleteStatus(string key, string dataPartner)
+        /// <summary>
+        /// Updates the complete status of a data partner for a given search request key in Redis. 
+        /// If the search request data is not found or cannot be deserialized, it will remove the cached entry. 
+        /// The method will retry up to a maximum number of attempts if there are concurrent updates to the same key.
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="dataPartner"></param>
+        /// <returns></returns>
+        public async Task UpdateDataPartnerCompleteStatus(string key, string dataPartner)
         {
-            if (string.IsNullOrEmpty(key)) throw new ArgumentNullException("Save : Key cannot be null");
-            bool committed = false;
+            _logger.LogInformation(
+                $"UpdateDataPartnerCompleteStatus - Updating complete status for search request key: {key}. Data partner: {dataPartner}."
+            );
+
+            if (string.IsNullOrEmpty(key))
+            {
+                throw new ArgumentNullException("UpdateDataPartnerCompleteStatus - Key cannot be null");
+            }
+
             int tryCounts = 0;
             int MAX_TRY_COUNT = 1000;
-            while (!committed && tryCounts<MAX_TRY_COUNT)
+            while (tryCounts < MAX_TRY_COUNT)
             {
                 tryCounts++;
-                RedisValue oldValue = await _stackRedisCacheClient.Db0.Database.HashGetAsync(key, new RedisValue("data"));
-                var searchRequest=JsonConvert.DeserializeObject<SearchRequest>(oldValue.ToString());
-                if (searchRequest != null)
+
+                // Get the current search request data from Redis hash value
+                RedisValue currentCachedValue = await _stackRedisCacheClient.Db0.Database.HashGetAsync(key, new RedisValue("data"));
+                var searchRequest = currentCachedValue.IsNullOrEmpty
+                    ? null
+                    : JsonConvert.DeserializeObject<SearchRequest>(currentCachedValue.ToString());
+
+                if (searchRequest == null)
                 {
-                    var partner = searchRequest.DataPartners?.FirstOrDefault(x => x.Name == dataPartner);
-                    if (partner != null)
+                    _logger.LogInformation(
+                        $"UpdateDataPartnerCompleteStatus - The 'data' field for key: {key} is missing or could not be deserialized into a search request. Nothing to update."
+                    );
+
+                    // If the value of the deserialized 'data' field is null, then delete the field from Redis hash value.
+                    if (!currentCachedValue.IsNullOrEmpty)
                     {
-                        partner.Completed = true;
+                        _logger.LogWarning(
+                            "UpdateDataPartnerCompleteStatus - The 'data' field for key {Key} could not be deserialized (corrupt data). Removing the 'data' field from the cache entry.",
+                            key
+                        );
+
+                        var cleanupTransaction = _stackRedisCacheClient.Db0.Database.CreateTransaction();
+                        cleanupTransaction.AddCondition(Condition.HashEqual(key, new RedisValue("data"), currentCachedValue));
+                        var cleanupTask = cleanupTransaction.HashDeleteAsync(key, new RedisValue("data"));
+
+                        if (await cleanupTransaction.ExecuteAsync())
+                        {
+                            await cleanupTask;
+                        }
                     }
+
+                    // No non-null search request data found, therefore nothing to update, break out of the loop early
+                    break;
                 }
-                var trans = _stackRedisCacheClient.Db0.Database.CreateTransaction();
-                trans.AddCondition(Condition.HashEqual(key, new RedisValue("data"), oldValue));
-                string newData = JsonConvert.SerializeObject(searchRequest);
-                var task = trans.HashSetAsync(key, new RedisValue("data"),new RedisValue(newData),When.Always, CommandFlags.None);
-                if (await trans.ExecuteAsync())
+
+                var partner = searchRequest.DataPartners?.FirstOrDefault(item => item.Name == dataPartner);
+                if (partner != null)
                 {
-                    var foo = await task;
-                    committed = true;
+                    _logger.LogInformation(
+                        $"UpdateDataPartnerCompleteStatus - Search request found, updating the partner's completed status to true for key: {key}. Data partner: {dataPartner}."
+                    );
+                    // Search request found, update the partner's completed status to true
+                    partner.Completed = true;
+                }
+
+                // Update the search request in Redis
+                var updateTransaction = _stackRedisCacheClient.Db0.Database.CreateTransaction();
+                updateTransaction.AddCondition(Condition.HashEqual(key, new RedisValue("data"), currentCachedValue));
+                var updateTask = updateTransaction.HashSetAsync(
+                    key,
+                    new RedisValue("data"),
+                    new RedisValue(JsonConvert.SerializeObject(searchRequest)),
+                    When.Always,
+                    CommandFlags.None
+                );
+
+                if (await updateTransaction.ExecuteAsync())
+                {
+                    await updateTask;
+                    break;
                 }
             }
-            return tryCounts;
+
+            return;
         }
     }
 }

--- a/app/SearchApi/SearchApi.Web/DeepSearch/IDeepSearchService.cs
+++ b/app/SearchApi/SearchApi.Web/DeepSearch/IDeepSearchService.cs
@@ -85,25 +85,30 @@ namespace SearchApi.Web.DeepSearch
                 return false;
             }
         }
+
+        /// <summary>
+        /// Updates the complete status of a data partner for a given search request key in Redis.
+        /// </summary>
+        /// <param name="searchRequestKey"></param>
+        /// <param name="dataPartner"></param>
+        /// <param name="eventName"></param>
+        /// <returns></returns>
         public async Task UpdateDataPartner(string searchRequestKey, string dataPartner, string eventName)
         {
             try
             {
                 if (eventName.Equals(EventName.Completed) || eventName.Equals(EventName.Rejected))
                 {
-                    _logger.LogInformation($"Updating data partner as completed for {dataPartner} for {eventName} event");
-                    int tryCount = await _cacheService.UpdateDataPartnerCompleteStatus(searchRequestKey, dataPartner);
-                    _logger.LogInformation("Successfully update data partner status with {tries}",tryCount);
+                    await _cacheService.UpdateDataPartnerCompleteStatus(searchRequestKey, dataPartner);
                 }
             }
             catch (Exception exception)
             {
-                _logger.LogError($"Update Data Partner Status Failed. [{eventName}] for {searchRequestKey}. [{exception.Message}]");
-
+                _logger.LogError(
+                    $"UpdateDataPartner - Update Data Partner Status Failed. [{eventName}] for {searchRequestKey}. [{exception.Message}]"
+                );
             }
         }
-
-       
 
         public  async Task DeleteFromCache(string searchRequestKey)
         {


### PR DESCRIPTION
## Ticket

https://jira.justice.gov.bc.ca/browse/FAMS3-4276

## Changes

Fix a bug in the `UpdateDataPartnerCompleteStatus` function, which didn't correctly handle a case where the value of the redis hash field is a string `"null"`.

Added some extra log messages.

Added csharpier file.
Formatted touched code.

## Bug

### Previously
Previously, the code would fetch the value, and check that it wasn't null. Since `"null"` is not `null`, it would pass the check. Downstream, it would try and perform some methods on the null value, which would throw an exception.

### Now
The code checks if the value is null, and removes that field from the hash value in redis. So downstream code that tries to fetch it will correctly receive a null value, and act accordingly.
