### PR TITLE
FAMS3-4276-3: Additional Error Handling + Tests

### DIFF
--- a/app/DynamicsAdapter/DynamicsAdapter.Web.Test/Register/SearchRequestRegisterTest.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web.Test/Register/SearchRequestRegisterTest.cs
@@ -427,6 +427,122 @@ namespace DynamicsAdapter.Web.Test.Register
             bool result = await _sut.DeleteSearchResponseReady("deleteFileId", "referenceId");
             Assert.AreEqual(true, result);
         }
+
+        [Test]
+        public async Task no_cached_data_DataPartnerSearchIsComplete_returns_true()
+        {
+            string key = "missing-search-request-key";
+            _cacheServiceMock.Setup(x => x.GetString(key)).Returns(Task.FromResult<string>(null));
+
+            bool result = await _sut.DataPartnerSearchIsComplete(key);
+
+            Assert.AreEqual(true, result);
+        }
+
+        [Test]
+        public async Task empty_string_cached_data_DataPartnerSearchIsComplete_returns_true()
+        {
+            string key = "empty-search-request-key";
+            _cacheServiceMock.Setup(x => x.GetString(key)).Returns(Task.FromResult(string.Empty));
+
+            bool result = await _sut.DataPartnerSearchIsComplete(key);
+
+            Assert.AreEqual(true, result);
+        }
+
+        [Test]
+        public async Task literal_null_json_cached_data_DataPartnerSearchIsComplete_returns_true()
+        {
+            string key = "null-search-request-key";
+            _cacheServiceMock.Setup(x => x.GetString(key)).Returns(Task.FromResult("null"));
+
+            bool result = await _sut.DataPartnerSearchIsComplete(key);
+
+            Assert.AreEqual(true, result);
+        }
+
+        [Test]
+        public async Task non_object_json_cached_data_DataPartnerSearchIsComplete_returns_true()
+        {
+            string key = "array-search-request-key";
+            _cacheServiceMock.Setup(x => x.GetString(key)).Returns(Task.FromResult("[1,2,3]"));
+
+            bool result = await _sut.DataPartnerSearchIsComplete(key);
+
+            Assert.AreEqual(true, result);
+        }
+
+        [Test]
+        public async Task malformed_json_cached_data_DataPartnerSearchIsComplete_returns_true()
+        {
+            string key = "malformed-search-request-key";
+            _cacheServiceMock.Setup(x => x.GetString(key)).Returns(Task.FromResult("{not valid json"));
+
+            bool result = await _sut.DataPartnerSearchIsComplete(key);
+
+            Assert.AreEqual(true, result);
+        }
+
+        [Test]
+        public async Task object_json_missing_data_partners_property_DataPartnerSearchIsComplete_returns_true()
+        {
+            string key = "no-data-partners-property-key";
+            _cacheServiceMock.Setup(x => x.GetString(key)).Returns(Task.FromResult("{}"));
+
+            bool result = await _sut.DataPartnerSearchIsComplete(key);
+
+            Assert.AreEqual(true, result);
+        }
+
+        [Test]
+        public async Task object_json_with_empty_data_partners_array_DataPartnerSearchIsComplete_returns_true()
+        {
+            string key = "empty-data-partners-key";
+            var cachedData = new { DataPartners = new object[0] };
+            _cacheServiceMock.Setup(x => x.GetString(key)).Returns(Task.FromResult(JsonConvert.SerializeObject(cachedData)));
+
+            bool result = await _sut.DataPartnerSearchIsComplete(key);
+
+            Assert.AreEqual(true, result);
+        }
+
+        [Test]
+        public async Task all_data_partners_completed_DataPartnerSearchIsComplete_returns_true()
+        {
+            string key = "all-complete-search-request-key";
+            var cachedData = new
+            {
+                DataPartners = new[]
+                {
+                    new { Name = "ICBC", Completed = true },
+                    new { Name = "BCHydro", Completed = true }
+                }
+            };
+            _cacheServiceMock.Setup(x => x.GetString(key)).Returns(Task.FromResult(JsonConvert.SerializeObject(cachedData)));
+
+            bool result = await _sut.DataPartnerSearchIsComplete(key);
+
+            Assert.AreEqual(true, result);
+        }
+
+        [Test]
+        public async Task some_data_partners_incomplete_DataPartnerSearchIsComplete_returns_false()
+        {
+            string key = "some-incomplete-search-request-key";
+            var cachedData = new
+            {
+                DataPartners = new[]
+                {
+                    new { Name = "ICBC", Completed = true },
+                    new { Name = "BCHydro", Completed = false }
+                }
+            };
+            _cacheServiceMock.Setup(x => x.GetString(key)).Returns(Task.FromResult(JsonConvert.SerializeObject(cachedData)));
+
+            bool result = await _sut.DataPartnerSearchIsComplete(key);
+
+            Assert.AreEqual(false, result);
+        }
     }
 }
 

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/Register/SearchRequestRegister.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/Register/SearchRequestRegister.cs
@@ -181,7 +181,7 @@ namespace DynamicsAdapter.Web.Register
             SSG_SearchApiRequest searchApiReqeust = await GetSearchApiRequest(searchApiRequestId);
             if (searchApiReqeust == null)
             {
-                _logger.LogWarning("Cannot find the searchApiRequest in Redis Cache.");
+                _logger.LogError("Cannot find the searchApiRequest in Redis Cache.");
                 return null;
             }
             if (identifer == null)
@@ -205,7 +205,7 @@ namespace DynamicsAdapter.Web.Register
             
             if (searchApiRequest == null)
             {
-                _logger.LogWarning("Cannot find the searchApiRequest in Redis Cache.");
+                _logger.LogError("Cannot find the searchApiRequest in Redis Cache.");
                 return null;
             }
             if (identifer == null)
@@ -298,8 +298,32 @@ namespace DynamicsAdapter.Web.Register
                 return true;
             }
 
+            JToken parsedData;
+            try
+            {
+                parsedData = JToken.Parse(data);
+            }
+            catch (JsonReaderException ex)
+            {
+                _logger.LogWarning(
+                    ex,
+                    $"DataPartnerSearchIsComplete - Cached data for searchRequestKey: {searchRequestKey} is not valid JSON. Returning true."
+                );
+
+                return true;
+            }
+
+            if (parsedData.Type != JTokenType.Object)
+            {
+                _logger.LogWarning(
+                    $"DataPartnerSearchIsComplete - Cached data for searchRequestKey: {searchRequestKey} is not a valid object. Returning true."
+                );
+
+                return true;
+            }
+
             // Find all DataPartners where Completed is false
-            IEnumerable<JToken> incompleteRecords = JObject.Parse(data).SelectTokens("$.DataPartners[?(@.Completed == false)]");
+            IEnumerable<JToken> incompleteRecords = ((JObject)parsedData).SelectTokens("$.DataPartners[?(@.Completed == false)]");
             var incompleteCount = incompleteRecords.Count();
 
             _logger.LogInformation(

--- a/app/SearchApi/BcGov.Fams3.Redis.Test/CacheServiceTest.cs
+++ b/app/SearchApi/BcGov.Fams3.Redis.Test/CacheServiceTest.cs
@@ -20,6 +20,8 @@ namespace BcGov.Fams3.Redis.Test
         private Mock<IDistributedCache> _distributedCacheMock;
         private Mock<IRedisCacheClient> _stackRedisCacheClientMock;
         private Mock<IRedisDatabase> _mockRedisDB;
+        private Mock<IDatabase> _mockDatabase;
+        private Mock<ITransaction> _mockTransaction;
         private Mock<ILogger<CacheService>> _loggerMock;
         private ICacheService _sut;
         private string _existedRequestKey;
@@ -102,6 +104,16 @@ namespace BcGov.Fams3.Redis.Test
             _mockRedisDB.Setup(x => x.SearchKeysAsync("test")).Returns(Task.FromResult(new List<string> {  }.AsEnumerable()));
             _mockRedisDB.Setup(x => x.GetAsync<string>("key", default)).Returns(Task.FromResult("data"));
             //_stackRedisCacheClient.Db0.GetAsync<string>(key)
+
+            _mockDatabase = new Mock<IDatabase>();
+            _mockRedisDB.Setup(x => x.Database).Returns(_mockDatabase.Object);
+
+            _mockTransaction = new Mock<ITransaction>();
+            _mockDatabase.Setup(x => x.CreateTransaction(It.IsAny<object>())).Returns(_mockTransaction.Object);
+            _mockTransaction.Setup(x => x.ExecuteAsync(It.IsAny<CommandFlags>())).ReturnsAsync(true);
+            _mockTransaction.Setup(x => x.HashSetAsync(It.IsAny<RedisKey>(), It.IsAny<RedisValue>(), It.IsAny<RedisValue>(), It.IsAny<When>(), It.IsAny<CommandFlags>())).ReturnsAsync(true);
+            _mockTransaction.Setup(x => x.HashDeleteAsync(It.IsAny<RedisKey>(), It.IsAny<RedisValue>(), It.IsAny<CommandFlags>())).ReturnsAsync(true);
+
             _loggerMock = new Mock<ILogger<CacheService>>();
 
             _sut = new CacheService(_distributedCacheMock.Object, _stackRedisCacheClientMock.Object, _loggerMock.Object);
@@ -322,6 +334,162 @@ namespace BcGov.Fams3.Redis.Test
         {
             Assert.ThrowsAsync<ArgumentNullException>(() => _sut.Delete(null));
 
+        }
+
+        [Test]
+        public void update_data_partner_complete_status_with_null_key_throws_exception()
+        {
+            Assert.ThrowsAsync<ArgumentNullException>(() => _sut.UpdateDataPartnerCompleteStatus(null, "ICBC"));
+        }
+
+        [Test]
+        public async Task update_data_partner_complete_status_with_missing_cache_entry_does_nothing()
+        {
+            string key = "missing-key";
+            _mockDatabase.Setup(x => x.HashGetAsync(key, "data", It.IsAny<CommandFlags>()))
+                .ReturnsAsync(RedisValue.Null);
+
+            await _sut.UpdateDataPartnerCompleteStatus(key, "ICBC");
+
+            _mockDatabase.Verify(x => x.HashGetAsync(key, "data", It.IsAny<CommandFlags>()), Times.Once);
+            _mockTransaction.Verify(x => x.HashSetAsync(It.IsAny<RedisKey>(), It.IsAny<RedisValue>(), It.IsAny<RedisValue>(), It.IsAny<When>(), It.IsAny<CommandFlags>()), Times.Never);
+            _mockTransaction.Verify(x => x.HashDeleteAsync(It.IsAny<RedisKey>(), It.IsAny<RedisValue>(), It.IsAny<CommandFlags>()), Times.Never);
+        }
+
+        [Test]
+        public async Task update_data_partner_complete_status_with_corrupt_data_removes_cache_field()
+        {
+            string key = "corrupt-key";
+            _mockDatabase.Setup(x => x.HashGetAsync(key, "data", It.IsAny<CommandFlags>()))
+                .ReturnsAsync(new RedisValue("null"));
+
+            await _sut.UpdateDataPartnerCompleteStatus(key, "ICBC");
+
+            _mockTransaction.Verify(x => x.HashDeleteAsync(key, "data", It.IsAny<CommandFlags>()), Times.Once);
+            _mockTransaction.Verify(x => x.HashSetAsync(It.IsAny<RedisKey>(), It.IsAny<RedisValue>(), It.IsAny<RedisValue>(), It.IsAny<When>(), It.IsAny<CommandFlags>()), Times.Never);
+        }
+
+        [Test]
+        public async Task update_data_partner_complete_status_with_matching_partner_marks_completed()
+        {
+            string key = "match-key";
+            var searchRequest = new SearchRequest
+            {
+                SearchRequestKey = key,
+                DataPartners = new List<DataPartner>
+                {
+                    new DataPartner { Name = "ICBC", Completed = false },
+                    new DataPartner { Name = "BCHydro", Completed = false }
+                }
+            };
+            _mockDatabase.Setup(x => x.HashGetAsync(key, "data", It.IsAny<CommandFlags>()))
+                .ReturnsAsync(new RedisValue(JsonConvert.SerializeObject(searchRequest)));
+
+            RedisValue capturedValue = RedisValue.Null;
+            _mockTransaction
+                .Setup(x => x.HashSetAsync(key, "data", It.IsAny<RedisValue>(), When.Always, CommandFlags.None))
+                .Callback<RedisKey, RedisValue, RedisValue, When, CommandFlags>((k, f, v, w, flags) => capturedValue = v)
+                .ReturnsAsync(true);
+
+            await _sut.UpdateDataPartnerCompleteStatus(key, "ICBC");
+
+            _mockTransaction.Verify(x => x.HashSetAsync(key, "data", It.IsAny<RedisValue>(), When.Always, CommandFlags.None), Times.Once);
+            var updated = JsonConvert.DeserializeObject<SearchRequest>(capturedValue.ToString());
+            Assert.IsTrue(updated.DataPartners.First(p => p.Name == "ICBC").Completed);
+            Assert.IsFalse(updated.DataPartners.First(p => p.Name == "BCHydro").Completed);
+        }
+
+        [Test]
+        public async Task update_data_partner_complete_status_with_unknown_partner_still_writes_back_data()
+        {
+            string key = "unknown-partner-key";
+            var searchRequest = new SearchRequest
+            {
+                SearchRequestKey = key,
+                DataPartners = new List<DataPartner>
+                {
+                    new DataPartner { Name = "ICBC", Completed = false }
+                }
+            };
+            _mockDatabase.Setup(x => x.HashGetAsync(key, "data", It.IsAny<CommandFlags>()))
+                .ReturnsAsync(new RedisValue(JsonConvert.SerializeObject(searchRequest)));
+
+            await _sut.UpdateDataPartnerCompleteStatus(key, "UnknownPartner");
+
+            _mockTransaction.Verify(x => x.HashSetAsync(key, "data", It.IsAny<RedisValue>(), When.Always, CommandFlags.None), Times.Once);
+        }
+
+        [Test]
+        public async Task update_data_partner_complete_status_retries_when_transaction_fails_then_succeeds()
+        {
+            string key = "retry-key";
+            var searchRequest = new SearchRequest
+            {
+                SearchRequestKey = key,
+                DataPartners = new List<DataPartner> { new DataPartner { Name = "ICBC", Completed = false } }
+            };
+            _mockDatabase.Setup(x => x.HashGetAsync(key, "data", It.IsAny<CommandFlags>()))
+                .ReturnsAsync(new RedisValue(JsonConvert.SerializeObject(searchRequest)));
+
+            _mockTransaction.SetupSequence(x => x.ExecuteAsync(It.IsAny<CommandFlags>()))
+                .ReturnsAsync(false)
+                .ReturnsAsync(true);
+
+            await _sut.UpdateDataPartnerCompleteStatus(key, "ICBC");
+
+            _mockDatabase.Verify(x => x.HashGetAsync(key, "data", It.IsAny<CommandFlags>()), Times.Exactly(2));
+            _mockTransaction.Verify(x => x.ExecuteAsync(It.IsAny<CommandFlags>()), Times.Exactly(2));
+        }
+
+        [Test]
+        public async Task update_data_partner_complete_status_exceeds_max_retries_returns_without_throwing()
+        {
+            string key = "always-fails-key";
+            var searchRequest = new SearchRequest
+            {
+                SearchRequestKey = key,
+                DataPartners = new List<DataPartner> { new DataPartner { Name = "ICBC", Completed = false } }
+            };
+            _mockDatabase.Setup(x => x.HashGetAsync(key, "data", It.IsAny<CommandFlags>()))
+                .ReturnsAsync(new RedisValue(JsonConvert.SerializeObject(searchRequest)));
+
+            _mockTransaction.Setup(x => x.ExecuteAsync(It.IsAny<CommandFlags>())).ReturnsAsync(false);
+
+            await _sut.UpdateDataPartnerCompleteStatus(key, "ICBC");
+
+            _mockDatabase.Verify(x => x.HashGetAsync(key, "data", It.IsAny<CommandFlags>()), Times.Exactly(1000));
+            _mockTransaction.Verify(x => x.ExecuteAsync(It.IsAny<CommandFlags>()), Times.Exactly(1000));
+        }
+
+        [Test]
+        public async Task update_data_partner_complete_status_with_corrupt_data_does_not_retry_when_cleanup_transaction_fails()
+        {
+            string key = "corrupt-key-no-retry";
+            _mockDatabase.Setup(x => x.HashGetAsync(key, "data", It.IsAny<CommandFlags>()))
+                .ReturnsAsync(new RedisValue("null"));
+            _mockTransaction.Setup(x => x.ExecuteAsync(It.IsAny<CommandFlags>())).ReturnsAsync(false);
+
+            await _sut.UpdateDataPartnerCompleteStatus(key, "ICBC");
+
+            _mockDatabase.Verify(x => x.HashGetAsync(key, "data", It.IsAny<CommandFlags>()), Times.Once);
+            _mockTransaction.Verify(x => x.HashDeleteAsync(key, "data", It.IsAny<CommandFlags>()), Times.Once);
+        }
+
+        [Test]
+        public async Task update_data_partner_complete_status_with_null_data_partners_collection_still_writes_back_data()
+        {
+            string key = "null-partners-key";
+            var searchRequest = new SearchRequest
+            {
+                SearchRequestKey = key,
+                DataPartners = null
+            };
+            _mockDatabase.Setup(x => x.HashGetAsync(key, "data", It.IsAny<CommandFlags>()))
+                .ReturnsAsync(new RedisValue(JsonConvert.SerializeObject(searchRequest)));
+
+            await _sut.UpdateDataPartnerCompleteStatus(key, "ICBC");
+
+            _mockTransaction.Verify(x => x.HashSetAsync(key, "data", It.IsAny<RedisValue>(), When.Always, CommandFlags.None), Times.Once);
         }
     }
 }


### PR DESCRIPTION
## Ticket

https://jira.justice.gov.bc.ca/browse/FAMS3-4276

## Changes

Add additional error handling to DataPartnerSearchIsComplete.
Add unit tests for DataPartnerSearchIsComplete and UpdateDataPartnerCompleteStatus.