### PR TITLE
[FAMS3-4384] dynamics cloud migration, JWT authentication implementation

### DIFF
--- a/app/DynamicsAdapter/DynamicsAdapter.Web/Auth/ConditionalAuthorizationHandler.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/Auth/ConditionalAuthorizationHandler.cs
@@ -1,0 +1,44 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Configuration;
+using Serilog;
+using System.Threading.Tasks;
+
+namespace DynamicsAdapter.Web.Auth
+{
+    /// <summary>
+    /// Authorization handler that respects the <c>auth:jwt:enabled</c> feature flag.
+    /// When the flag is false, all requests are allowed through regardless of authentication state.
+    /// When the flag is true, the request must carry a valid JWT bearer token.
+    /// </summary>
+    public class ConditionalAuthorizationHandler : AuthorizationHandler<ConditionalAuthorizationRequirement>
+    {
+        private readonly IConfiguration _configuration;
+
+        public ConditionalAuthorizationHandler(IConfiguration configuration)
+        {
+            _configuration = configuration;
+        }
+
+        protected override Task HandleRequirementAsync(
+            AuthorizationHandlerContext context,
+            ConditionalAuthorizationRequirement requirement)
+        {
+            // Default to true — if no config value is present, enforce JWT (fail secure)
+            var authEnabled = _configuration.GetValue<bool>("auth:jwt:enabled", defaultValue: true);
+
+            if (!authEnabled)
+            {
+                Log.Debug("Authentication is disabled via feature flag. Allowing unauthenticated access.");
+                context.Succeed(requirement);
+                return Task.CompletedTask;
+            }
+
+            if (context.User.Identity?.IsAuthenticated == true)
+            {
+                context.Succeed(requirement);
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/Auth/ConditionalAuthorizationHandler.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/Auth/ConditionalAuthorizationHandler.cs
@@ -28,7 +28,7 @@ namespace DynamicsAdapter.Web.Auth
 
             if (!authEnabled)
             {
-                Log.Debug("Authentication is disabled via feature flag. Allowing unauthenticated access.");
+                Log.Debug("JWT Authentication is disabled via feature flag. Falling back to API key authentication.");
                 context.Succeed(requirement);
                 return Task.CompletedTask;
             }

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/Auth/ConditionalAuthorizationRequirement.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/Auth/ConditionalAuthorizationRequirement.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Authorization;
+
+namespace DynamicsAdapter.Web.Auth
+{
+    public class ConditionalAuthorizationRequirement : IAuthorizationRequirement
+    {
+    }
+}

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/Auth/RequestApiTokenHandler.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/Auth/RequestApiTokenHandler.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+using IdentityModel.Client;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace DynamicsAdapter.Web.Auth
+{
+    public class RequestApiTokenHandler : DelegatingHandler
+    {
+        private const string CacheKey = "request_api_access_token";
+
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly IMemoryCache _cache;
+        private readonly IConfiguration _configuration;
+        private readonly ILogger<RequestApiTokenHandler> _logger;
+
+        public RequestApiTokenHandler(
+            IHttpClientFactory httpClientFactory,
+            IMemoryCache cache,
+            IConfiguration configuration,
+            ILogger<RequestApiTokenHandler> logger)
+        {
+            _httpClientFactory = httpClientFactory;
+            _cache = cache;
+            _configuration = configuration;
+            _logger = logger;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var token = await GetTokenAsync(cancellationToken);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            return await base.SendAsync(request, cancellationToken);
+        }
+
+        private async Task<string> GetTokenAsync(CancellationToken cancellationToken)
+        {
+            if (_cache.TryGetValue(CacheKey, out string cachedToken) && !string.IsNullOrWhiteSpace(cachedToken))
+            {
+                return cachedToken;
+            }
+
+            var tokenUrl = _configuration["auth:requestApi:tokenUrl"];
+            var clientId = _configuration["auth:requestApi:clientId"];
+            var clientSecret = _configuration["auth:requestApi:clientSecret"];
+
+            if (string.IsNullOrWhiteSpace(tokenUrl) || string.IsNullOrWhiteSpace(clientId) || string.IsNullOrWhiteSpace(clientSecret))
+            {
+                throw new InvalidOperationException("Request API token configuration is incomplete. Set auth:requestApi:tokenUrl, auth:requestApi:clientId, and auth:requestApi:clientSecret.");
+            }
+
+            using var httpClient = _httpClientFactory.CreateClient("request_api_token");
+            var response = await httpClient.RequestClientCredentialsTokenAsync(
+                new ClientCredentialsTokenRequest
+                {
+                    Address = tokenUrl,
+                    ClientId = clientId,
+                    ClientSecret = clientSecret,
+                },
+                cancellationToken
+            );
+
+            if (response.IsError)
+            {
+                _logger.LogError(
+                    "Request API token acquisition failed: {Error} - {Description}",
+                    response.Error,
+                    response.ErrorDescription);
+
+                throw new InvalidOperationException(
+                    $"Request API token acquisition failed: {response.Error} - {response.ErrorDescription}");
+            }
+
+            var expiresIn = response.ExpiresIn > 60 ? response.ExpiresIn - 60 : response.ExpiresIn;
+            _cache.Set(CacheKey, response.AccessToken, TimeSpan.FromSeconds(expiresIn));
+
+            return response.AccessToken;
+        }
+    }
+}

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/Auth/RequestApiTokenHandler.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/Auth/RequestApiTokenHandler.cs
@@ -1,15 +1,19 @@
+using IdentityModel.Client;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Threading;
 using System.Threading.Tasks;
-using IdentityModel.Client;
-using Microsoft.Extensions.Caching.Memory;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
 
 namespace DynamicsAdapter.Web.Auth
 {
+    /// <summary>
+    /// HTTP message handler for outbound requests to request-api.
+    /// Toggles between JWT bearer token (when enabled) and X-ApiKey header (when disabled).
+    /// </summary>
     public class RequestApiTokenHandler : DelegatingHandler
     {
         private const string CacheKey = "request_api_access_token";
@@ -35,8 +39,27 @@ namespace DynamicsAdapter.Web.Auth
             HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
-            var token = await GetTokenAsync(cancellationToken);
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            var jwtEnabled = _configuration.GetValue<bool>("auth:requestApi:enabled", defaultValue: false);
+
+            if (jwtEnabled)
+            {
+                var token = await GetTokenAsync(cancellationToken);
+                if (!string.IsNullOrEmpty(token))
+                {
+                    request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+                    _logger.LogDebug("Request sent with JWT bearer token");
+                }
+            }
+            else
+            {
+                var apiKey = _configuration["ApiKeyForRequestApi"];
+                if (!string.IsNullOrEmpty(apiKey))
+                {
+                    request.Headers.Add("X-ApiKey", apiKey);
+                    _logger.LogDebug("Request sent with X-ApiKey header (JWT disabled)");
+                }
+            }
+
             return await base.SendAsync(request, cancellationToken);
         }
 
@@ -53,35 +76,41 @@ namespace DynamicsAdapter.Web.Auth
 
             if (string.IsNullOrWhiteSpace(tokenUrl) || string.IsNullOrWhiteSpace(clientId) || string.IsNullOrWhiteSpace(clientSecret))
             {
-                throw new InvalidOperationException("Request API token configuration is incomplete. Set auth:requestApi:tokenUrl, auth:requestApi:clientId, and auth:requestApi:clientSecret.");
+                _logger.LogWarning("Request API token configuration incomplete. Proceeding without JWT token.");
+                return string.Empty;
             }
 
-            using var httpClient = _httpClientFactory.CreateClient("request_api_token");
-            var response = await httpClient.RequestClientCredentialsTokenAsync(
-                new ClientCredentialsTokenRequest
-                {
-                    Address = tokenUrl,
-                    ClientId = clientId,
-                    ClientSecret = clientSecret,
-                },
-                cancellationToken
-            );
-
-            if (response.IsError)
+            try
             {
-                _logger.LogError(
-                    "Request API token acquisition failed: {Error} - {Description}",
-                    response.Error,
-                    response.ErrorDescription);
+                using var httpClient = _httpClientFactory.CreateClient("request_api_token");
+                var response = await httpClient.RequestClientCredentialsTokenAsync(
+                    new ClientCredentialsTokenRequest
+                    {
+                        Address = tokenUrl,
+                        ClientId = clientId,
+                        ClientSecret = clientSecret,
+                    },
+                    cancellationToken);
 
-                throw new InvalidOperationException(
-                    $"Request API token acquisition failed: {response.Error} - {response.ErrorDescription}");
+                if (response.IsError)
+                {
+                    _logger.LogError(
+                        "Request API token acquisition failed: {Error} - {Description}",
+                        response.Error,
+                        response.ErrorDescription);
+                    return string.Empty;
+                }
+
+                var expiresIn = response.ExpiresIn > 60 ? response.ExpiresIn - 60 : response.ExpiresIn;
+                _cache.Set(CacheKey, response.AccessToken, TimeSpan.FromSeconds(expiresIn));
+
+                return response.AccessToken;
             }
-
-            var expiresIn = response.ExpiresIn > 60 ? response.ExpiresIn - 60 : response.ExpiresIn;
-            _cache.Set(CacheKey, response.AccessToken, TimeSpan.FromSeconds(expiresIn));
-
-            return response.AccessToken;
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Exception during token acquisition for request-api");
+                return string.Empty;
+            }
         }
     }
 }

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/Auth/RequestApiTokenHandler.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/Auth/RequestApiTokenHandler.cs
@@ -12,7 +12,8 @@ namespace DynamicsAdapter.Web.Auth
 {
     /// <summary>
     /// HTTP message handler for outbound requests to request-api.
-    /// Toggles between JWT bearer token (when enabled) and X-ApiKey header (when disabled).
+    /// Attaches a JWT bearer token when <c>auth:requestApi:enabled</c> is true.
+    /// When disabled, requests are forwarded unauthenticated — request-api does not enforce API key auth.
     /// </summary>
     public class RequestApiTokenHandler : DelegatingHandler
     {
@@ -52,12 +53,7 @@ namespace DynamicsAdapter.Web.Auth
             }
             else
             {
-                var apiKey = _configuration["ApiKeyForRequestApi"];
-                if (!string.IsNullOrEmpty(apiKey))
-                {
-                    request.Headers.Add("X-ApiKey", apiKey);
-                    _logger.LogDebug("Request sent with X-ApiKey header (JWT disabled)");
-                }
+                _logger.LogDebug("JWT disabled for request-api; forwarding request without auth header");
             }
 
             return await base.SendAsync(request, cancellationToken);

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/DynamicsAdapter.Web.csproj
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/DynamicsAdapter.Web.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="FluentValidation" Version="9.3.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="9.3.0" />
     <PackageReference Include="Jaeger" Version="1.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.15" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.1" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.9.10" />

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/DynamicsAdapter.Web.csproj
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/DynamicsAdapter.Web.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="FluentValidation" Version="9.3.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="9.3.0" />
     <PackageReference Include="Jaeger" Version="1.0.3" />
+    <PackageReference Include="IdentityModel" Version="7.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.15" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.1" />

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/PersonSearch/PersonSearchController.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/PersonSearch/PersonSearchController.cs
@@ -10,6 +10,7 @@ using Fams3Adapter.Dynamics.SearchApiEvent;
 using Fams3Adapter.Dynamics.SearchApiRequest;
 using Fams3Adapter.Dynamics.SearchRequest;
 using Fams3Adapter.Dynamics.Types;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -26,6 +27,7 @@ namespace DynamicsAdapter.Web.PersonSearch
 {
     [Route("[controller]")]
     [ApiController]
+    [Authorize]
     public class PersonSearchController : ControllerBase
     {
         private readonly ILogger<PersonSearchController> _logger;

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/AgencyRequestController.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/AgencyRequestController.cs
@@ -3,6 +3,7 @@ using DynamicsAdapter.Web.Register;
 using DynamicsAdapter.Web.SearchAgency.Exceptions;
 using DynamicsAdapter.Web.SearchAgency.Models;
 using Fams3Adapter.Dynamics.SearchRequest;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -16,6 +17,7 @@ namespace DynamicsAdapter.Web.SearchAgency
 {
     [Route("[controller]")]
     [ApiController]
+    [Authorize]
     public class AgencyRequestController : ControllerBase
     {
         private readonly ILogger<AgencyRequestController> _logger;

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/AgencyResponseController.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/SearchAgency/AgencyResponseController.cs
@@ -2,6 +2,7 @@
 using DynamicsAdapter.Web.Register;
 using DynamicsAdapter.Web.SearchAgency.Models;
 using DynamicsAdapter.Web.SearchAgency.Webhook;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -16,6 +17,7 @@ namespace DynamicsAdapter.Web.SearchAgency
 {
     [Route("[controller]")]
     [ApiController]
+    [Authorize]
     public class AgencyResponseController : ControllerBase
     {
         private readonly ILogger<AgencyResponseController> _logger;

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/Startup.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/Startup.cs
@@ -356,6 +356,14 @@ namespace DynamicsAdapter.Web
 
             app.UseRouting();
 
+            var jwtEnabled = Configuration.GetValue<bool>("auth:jwt:enabled", defaultValue: true);
+            if (!jwtEnabled)
+            {
+                app.UseWhen(
+                    context => !context.Request.Path.StartsWithSegments("/swagger"),
+                    appBuilder => appBuilder.UseMiddleware<ApiKeyMiddleware>("ApiKey"));
+            }
+
             app.UseAuthentication();
             app.UseAuthorization();
 

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/Startup.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/Startup.cs
@@ -11,6 +11,9 @@ using DynamicsAdapter.Web.Register;
 using DynamicsAdapter.Web.SearchAgency;
 using DynamicsAdapter.Web.SearchAgency.Models;
 using DynamicsAdapter.Web.SearchAgency.Validation;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.IdentityModel.Tokens;
 using DynamicsAdapter.Web.SearchAgency.Webhook;
 using DynamicsAdapter.Web.SearchRequest;
 using Fams3Adapter.Dynamics.DataProvider;
@@ -43,6 +46,7 @@ using Simple.OData.Client;
 using StackExchange.Redis.Extensions.Core.Configuration;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 
 namespace DynamicsAdapter.Web
 {
@@ -81,6 +85,7 @@ namespace DynamicsAdapter.Web
             this.ConfigureDynamicsClient(services);
 
             this.ConfigureScheduler(services);
+            this.ConfigureJwtAuthentication(services);
             this.ConfigureAutoMapper(services);
             this.ConfigureFluentValidation(services);
             services.AddCacheService(Configuration.GetSection(Keys.REDIS_SECTION_SETTING_KEY).Get<RedisConfiguration>());
@@ -89,6 +94,50 @@ namespace DynamicsAdapter.Web
             services.AddTransient<ISearchResultService, SearchResultService>();
             services.AddTransient<ISearchRequestRegister, SearchRequestRegister>();
 
+        }
+
+        /// <summary>
+        /// Configures Keycloak JWT bearer authentication and a flag-gated authorization policy.
+        /// Set <c>auth:jwt:enabled = true</c> in configuration to enforce JWT on all protected routes.
+        /// </summary>
+        private void ConfigureJwtAuthentication(IServiceCollection services)
+        {
+            services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+                .AddJwtBearer(options =>
+                {
+                    options.Authority = Configuration["auth:jwt:authority"];
+                    options.Audience = Configuration["auth:jwt:audience"];
+                    options.TokenValidationParameters = new TokenValidationParameters
+                    {
+                        ValidateIssuerSigningKey = true,
+                    };
+                    options.Events = new JwtBearerEvents
+                    {
+                        OnTokenValidated = context =>
+                        {
+                            var sub = context.Principal?.FindFirst("sub")?.Value ?? "unknown";
+                            Serilog.Log.Information("JWT token validated for subject {Subject}", sub);
+                            return Task.CompletedTask;
+                        },
+                        OnAuthenticationFailed = context =>
+                        {
+                            Serilog.Log.Warning("JWT authentication failed: {Error}", context.Exception.Message);
+                            return Task.CompletedTask;
+                        }
+                    };
+                });
+
+            services.AddSingleton<IAuthorizationHandler, ConditionalAuthorizationHandler>();
+
+            services.AddAuthorization(options =>
+            {
+                var conditionalPolicy = new AuthorizationPolicyBuilder()
+                    .AddRequirements(new ConditionalAuthorizationRequirement())
+                    .Build();
+
+                options.DefaultPolicy = conditionalPolicy;
+                options.FallbackPolicy = conditionalPolicy;
+            });
         }
 
         private void ConfigureFluentValidation(IServiceCollection services)
@@ -303,11 +352,8 @@ namespace DynamicsAdapter.Web
 
             app.UseRouting();
 
+            app.UseAuthentication();
             app.UseAuthorization();
-
-            app.UseWhen(
-                context => !context.Request.Path.StartsWithSegments("/swagger"),
-                appBuilder => appBuilder.UseMiddleware<ApiKeyMiddleware>("ApiKey"));
 
             app.UseOpenApi();
 
@@ -319,7 +365,7 @@ namespace DynamicsAdapter.Web
                     AllowCachingResponses = false,
                     Predicate = _ => true,
                     ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse
-                });
+                }).AllowAnonymous();
                 endpoints.MapDefaultControllerRoute();
             });
         }

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/Startup.cs
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/Startup.cs
@@ -74,7 +74,11 @@ namespace DynamicsAdapter.Web
 
             services.AddOptions<AgencyNotificationOptions>().Bind(Configuration.GetSection(Keys.AGENCY_NOTIFICATION_WEB_HOOK_SETTING_KEY));
             services.AddOptions<SearchApiConfiguration>().Bind(Configuration.GetSection("SearchApi"));
-            services.AddHttpClient<IAgencyNotificationWebhook<SearchRequestNotification>, AgencyNotificationWebhook>();
+            services.AddMemoryCache();
+            services.AddTransient<RequestApiTokenHandler>();
+            services.AddHttpClient("request_api_token");
+            services.AddHttpClient<IAgencyNotificationWebhook<SearchRequestNotification>, AgencyNotificationWebhook>()
+                .AddHttpMessageHandler<RequestApiTokenHandler>();
 
             services.AddHealthChecks().AddCheck<DynamicsHealthCheck>("status_reason_health_check", failureStatus: HealthStatus.Degraded);
 

--- a/app/DynamicsAdapter/DynamicsAdapter.Web/appsettings.json
+++ b/app/DynamicsAdapter/DynamicsAdapter.Web/appsettings.json
@@ -55,11 +55,18 @@
     "WebHooks": [
       {
         "Name": "RequestApi",
-        "Uri": "http://localhost:4000/api/Notification"
+        "Uri": "http://localhost:5070/api/Notification"
       }
     ]
   },
-  "ApiKey": "6f975845-91a7-4038-830a-eb222b2559fe",
+  "auth": {
+    "requestApi": {
+      "enabled": false,
+      "tokenUrl": "https://keycloak:8080/auth/realms/fams/protocol/openid-connect/token",
+      "clientId": "dynadapter",
+      "clientSecret": "replace-me"
+    }
+  },
   "TrustedHosts": "searchApi,requestApi,localhost",
   "JAEGER_SERVICE_NAME": "dynadapter"
 }

--- a/app/SearchApi/SearchApi.Web/Auth/DynadapterTokenHandler.cs
+++ b/app/SearchApi/SearchApi.Web/Auth/DynadapterTokenHandler.cs
@@ -1,0 +1,87 @@
+using IdentityModel.Client;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SearchApi.Web.Auth
+{
+    public class DynadapterTokenHandler : DelegatingHandler
+    {
+        private const string CacheKey = "dynadapter_access_token";
+
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly IMemoryCache _cache;
+        private readonly IConfiguration _configuration;
+        private readonly ILogger<DynadapterTokenHandler> _logger;
+
+        public DynadapterTokenHandler(
+            IHttpClientFactory httpClientFactory,
+            IMemoryCache cache,
+            IConfiguration configuration,
+            ILogger<DynadapterTokenHandler> logger)
+        {
+            _httpClientFactory = httpClientFactory;
+            _cache = cache;
+            _configuration = configuration;
+            _logger = logger;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var token = await GetTokenAsync(cancellationToken);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            return await base.SendAsync(request, cancellationToken);
+        }
+
+        private async Task<string> GetTokenAsync(CancellationToken cancellationToken)
+        {
+            if (_cache.TryGetValue(CacheKey, out string cachedToken) && !string.IsNullOrWhiteSpace(cachedToken))
+            {
+                return cachedToken;
+            }
+
+            var tokenUrl = _configuration["auth:dynadapter:tokenUrl"];
+            var clientId = _configuration["auth:dynadapter:clientId"];
+            var clientSecret = _configuration["auth:dynadapter:clientSecret"];
+
+            if (string.IsNullOrWhiteSpace(tokenUrl) || string.IsNullOrWhiteSpace(clientId) || string.IsNullOrWhiteSpace(clientSecret))
+            {
+                throw new InvalidOperationException("Dynadapter token configuration is incomplete. Set auth:dynadapter:tokenUrl, auth:dynadapter:clientId, and auth:dynadapter:clientSecret.");
+            }
+
+            using var httpClient = _httpClientFactory.CreateClient("dynadapter_token");
+            var response = await httpClient.RequestClientCredentialsTokenAsync(
+                new ClientCredentialsTokenRequest
+                {
+                    Address = tokenUrl,
+                    ClientId = clientId,
+                    ClientSecret = clientSecret,
+                },
+                cancellationToken
+            );
+
+            if (response.IsError)
+            {
+                _logger.LogError(
+                    "Dynadapter token acquisition failed: {Error} - {Description}",
+                    response.Error,
+                    response.ErrorDescription);
+
+                throw new InvalidOperationException(
+                    $"Dynadapter token acquisition failed: {response.Error} - {response.ErrorDescription}");
+            }
+
+            var expiresIn = response.ExpiresIn > 60 ? response.ExpiresIn - 60 : response.ExpiresIn;
+            _cache.Set(CacheKey, response.AccessToken, TimeSpan.FromSeconds(expiresIn));
+
+            return response.AccessToken;
+        }
+    }
+}

--- a/app/SearchApi/SearchApi.Web/Auth/DynadapterTokenHandler.cs
+++ b/app/SearchApi/SearchApi.Web/Auth/DynadapterTokenHandler.cs
@@ -10,6 +10,10 @@ using System.Threading.Tasks;
 
 namespace SearchApi.Web.Auth
 {
+    /// <summary>
+    /// HTTP message handler for outbound requests to dynadapter.
+    /// Toggles between JWT bearer token (when enabled) and X-ApiKey header (when disabled).
+    /// </summary>
     public class DynadapterTokenHandler : DelegatingHandler
     {
         private const string CacheKey = "dynadapter_access_token";
@@ -35,8 +39,27 @@ namespace SearchApi.Web.Auth
             HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
-            var token = await GetTokenAsync(cancellationToken);
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            var jwtEnabled = _configuration.GetValue<bool>("auth:dynadapter:enabled", defaultValue: false);
+
+            if (jwtEnabled)
+            {
+                var token = await GetTokenAsync(cancellationToken);
+                if (!string.IsNullOrEmpty(token))
+                {
+                    request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+                    _logger.LogDebug("Request sent with JWT bearer token");
+                }
+            }
+            else
+            {
+                var apiKey = _configuration["SearchApi:ApiKeyForDynadaptor"];
+                if (!string.IsNullOrEmpty(apiKey))
+                {
+                    request.Headers.Add("X-ApiKey", apiKey);
+                    _logger.LogDebug("Request sent with X-ApiKey header (JWT disabled)");
+                }
+            }
+
             return await base.SendAsync(request, cancellationToken);
         }
 
@@ -53,35 +76,41 @@ namespace SearchApi.Web.Auth
 
             if (string.IsNullOrWhiteSpace(tokenUrl) || string.IsNullOrWhiteSpace(clientId) || string.IsNullOrWhiteSpace(clientSecret))
             {
-                throw new InvalidOperationException("Dynadapter token configuration is incomplete. Set auth:dynadapter:tokenUrl, auth:dynadapter:clientId, and auth:dynadapter:clientSecret.");
+                _logger.LogWarning("Dynadapter token configuration incomplete. Proceeding without JWT token.");
+                return string.Empty;
             }
 
-            using var httpClient = _httpClientFactory.CreateClient("dynadapter_token");
-            var response = await httpClient.RequestClientCredentialsTokenAsync(
-                new ClientCredentialsTokenRequest
-                {
-                    Address = tokenUrl,
-                    ClientId = clientId,
-                    ClientSecret = clientSecret,
-                },
-                cancellationToken
-            );
-
-            if (response.IsError)
+            try
             {
-                _logger.LogError(
-                    "Dynadapter token acquisition failed: {Error} - {Description}",
-                    response.Error,
-                    response.ErrorDescription);
+                using var httpClient = _httpClientFactory.CreateClient("dynadapter_token");
+                var response = await httpClient.RequestClientCredentialsTokenAsync(
+                    new ClientCredentialsTokenRequest
+                    {
+                        Address = tokenUrl,
+                        ClientId = clientId,
+                        ClientSecret = clientSecret,
+                    },
+                    cancellationToken);
 
-                throw new InvalidOperationException(
-                    $"Dynadapter token acquisition failed: {response.Error} - {response.ErrorDescription}");
+                if (response.IsError)
+                {
+                    _logger.LogError(
+                        "Dynadapter token acquisition failed: {Error} - {Description}",
+                        response.Error,
+                        response.ErrorDescription);
+                    return string.Empty;
+                }
+
+                var expiresIn = response.ExpiresIn > 60 ? response.ExpiresIn - 60 : response.ExpiresIn;
+                _cache.Set(CacheKey, response.AccessToken, TimeSpan.FromSeconds(expiresIn));
+
+                return response.AccessToken;
             }
-
-            var expiresIn = response.ExpiresIn > 60 ? response.ExpiresIn - 60 : response.ExpiresIn;
-            _cache.Set(CacheKey, response.AccessToken, TimeSpan.FromSeconds(expiresIn));
-
-            return response.AccessToken;
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Exception during token acquisition for dynadapter");
+                return string.Empty;
+            }
         }
     }
 }

--- a/app/SearchApi/SearchApi.Web/Configuration/SearchApiOptions.cs
+++ b/app/SearchApi/SearchApi.Web/Configuration/SearchApiOptions.cs
@@ -8,7 +8,6 @@ namespace SearchApi.Web.Configuration
     public class SearchApiOptions
     {
         public List<WebHookNotification> WebHooks { get; set; } = new List<WebHookNotification>();
-        public string ApiKeyForDynadaptor { get; set; }
         public int Timeout { get; set; } = 2;
 
         public SearchApiOptions AddWebHook(string name, string uri)

--- a/app/SearchApi/SearchApi.Web/Notifications/ServiceCollectionExtensions.cs
+++ b/app/SearchApi/SearchApi.Web/Notifications/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using BcGov.Fams3.SearchApi.Contracts.PersonSearch;
 using Microsoft.Extensions.DependencyInjection;
+using SearchApi.Web.Auth;
 
 namespace SearchApi.Web.Notifications
 {
@@ -7,8 +8,11 @@ namespace SearchApi.Web.Notifications
     {
         public static void AddWebHooks(this IServiceCollection services)
         {
-            
-            services.AddHttpClient<ISearchApiNotifier<PersonSearchAdapterEvent>, WebHookNotifierSearchEventStatus>();
+            services.AddMemoryCache();
+            services.AddTransient<DynadapterTokenHandler>();
+            services.AddHttpClient("dynadapter_token");
+            services.AddHttpClient<ISearchApiNotifier<PersonSearchAdapterEvent>, WebHookNotifierSearchEventStatus>()
+                .AddHttpMessageHandler<DynadapterTokenHandler>();
         }
     }
 }

--- a/app/SearchApi/SearchApi.Web/Notifications/WebHookNotifierSearchEventStatus.cs
+++ b/app/SearchApi/SearchApi.Web/Notifications/WebHookNotifierSearchEventStatus.cs
@@ -14,21 +14,21 @@ using System.Collections.Generic;
 namespace SearchApi.Web.Notifications
 {
 
-    public class WebHookNotifierSearchEventStatus :  ISearchApiNotifier<PersonSearchAdapterEvent>
+    public class WebHookNotifierSearchEventStatus : ISearchApiNotifier<PersonSearchAdapterEvent>
     {
 
         private readonly HttpClient _httpClient;
         private readonly SearchApiOptions _searchApiOptions;
         private readonly IDeepSearchService _deepSearchService;
         private readonly ILogger<WebHookNotifierSearchEventStatus> _logger;
-     
+
 
         public WebHookNotifierSearchEventStatus(HttpClient httpClient, IOptions<SearchApiOptions> searchApiOptions,
             ILogger<WebHookNotifierSearchEventStatus> logger, IDeepSearchService deepSearchService)
         {
             _httpClient = httpClient;
             _logger = logger;
-            _searchApiOptions = searchApiOptions.Value;     
+            _searchApiOptions = searchApiOptions.Value;
             _deepSearchService = deepSearchService;
             _httpClient.Timeout = TimeSpan.FromMinutes(_searchApiOptions.Timeout);
         }
@@ -88,7 +88,6 @@ namespace SearchApi.Web.Notifications
                         request.Method = HttpMethod.Post;
                         request.Headers.Accept.Add(
                             System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
-                        request.Headers.Add("X-ApiKey", _searchApiOptions.ApiKeyForDynadaptor);
                         request.RequestUri = endpoint;
                         var response = await _httpClient.SendAsync(request, cancellationToken);
 
@@ -137,7 +136,7 @@ namespace SearchApi.Web.Notifications
                 else if (eventName.Equals(EventName.Completed))
                 {
                     PersonSearchCompletedJCA completed = (PersonSearchCompletedJCA)eventStatus;
-                    if(completed.Message != null && completed.Message.Contains("All traces received."))
+                    if (completed.Message != null && completed.Message.Contains("All traces received."))
                     {
                         await _deepSearchService.UpdateDataPartner(searchRequestKey, eventStatus.ProviderProfile.Name, eventName);
                     }
@@ -153,15 +152,15 @@ namespace SearchApi.Web.Notifications
 
             await ProcessWaveSearch(searchRequestKey, eventName, eventStatus.ProviderProfile.Name);
 
-           
-               
+
+
         }
 
-        private async Task ProcessWaveSearch(string searchRequestKey, string eventName,string dataPartner )
+        private async Task ProcessWaveSearch(string searchRequestKey, string eventName, string dataPartner)
         {
             if (!EventName.Finalized.Equals(eventName))
             {
-                if (EventName.Completed.Equals(eventName)|| EventName.Rejected.Equals(eventName))
+                if (EventName.Completed.Equals(eventName) || EventName.Rejected.Equals(eventName))
                 {
                     if (await _deepSearchService.IsWaveSearchReadyToFinalize(searchRequestKey))
                     {

--- a/app/SearchApi/SearchApi.Web/SearchApi.Web.csproj
+++ b/app/SearchApi/SearchApi.Web/SearchApi.Web.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+    <UserSecretsId>9d53de15-7baf-4435-98bf-b871cae05bb0</UserSecretsId>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -13,6 +14,7 @@
     <PackageReference Include="AspNetCore.HealthChecks.Rabbitmq" Version="3.1.4" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="8.0.1" />
     <PackageReference Include="AutoMapper" Version="14.0.0" />
+    <PackageReference Include="IdentityModel" Version="7.0.0" />
     <PackageReference Include="Jaeger" Version="1.0.3" />
     <PackageReference Include="MassTransit.AspNetCore" Version="6.2.3" />
     <PackageReference Include="MassTransit.RabbitMQ" Version="6.2.3" />

--- a/app/SearchApi/SearchApi.Web/appsettings.json
+++ b/app/SearchApi/SearchApi.Web/appsettings.json
@@ -39,15 +39,12 @@
       }
     ]
   },
-  "SearchApi": {
-    "WebHooks": [
-      {
-        "Name": "dynadapter",
-        "Uri": "http://localhost:5050/PersonSearch"
-      }
-    ],
-    "Timeout": "30",
-    "ApiKeyForDynadaptor": "6f975845-91a7-4038-830a-eb222b2559fe"
+  "auth": {
+    "dynadapter": {
+      "enabled": false,
+      "tokenUrl": "https://keycloak:8080/auth/realms/fams/protocol/openid-connect/token",
+      "clientId": "search-api",
+      "clientSecret": "replace-me"
+    }
   }
-  
 }

--- a/app/SearchApi/SearchRequest.Adaptor/Auth/ConditionalAuthorizationHandler.cs
+++ b/app/SearchApi/SearchRequest.Adaptor/Auth/ConditionalAuthorizationHandler.cs
@@ -1,0 +1,38 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Configuration;
+using Serilog;
+using System.Threading.Tasks;
+
+namespace SearchRequestAdaptor.Auth
+{
+    public class ConditionalAuthorizationHandler : AuthorizationHandler<ConditionalAuthorizationRequirement>
+    {
+        private readonly IConfiguration _configuration;
+
+        public ConditionalAuthorizationHandler(IConfiguration configuration)
+        {
+            _configuration = configuration;
+        }
+
+        protected override Task HandleRequirementAsync(
+            AuthorizationHandlerContext context,
+            ConditionalAuthorizationRequirement requirement)
+        {
+            var authEnabled = _configuration.GetValue<bool>("auth:jwt:enabled");
+
+            if (!authEnabled)
+            {
+                Log.Debug("Authentication is disabled via feature flag. Allowing unauthenticated access.");
+                context.Succeed(requirement);
+                return Task.CompletedTask;
+            }
+
+            if (context.User.Identity?.IsAuthenticated == true)
+            {
+                context.Succeed(requirement);
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/app/SearchApi/SearchRequest.Adaptor/Auth/ConditionalAuthorizationRequirement.cs
+++ b/app/SearchApi/SearchRequest.Adaptor/Auth/ConditionalAuthorizationRequirement.cs
@@ -1,0 +1,8 @@
+using Microsoft.AspNetCore.Authorization;
+
+namespace SearchRequestAdaptor.Auth
+{
+    public class ConditionalAuthorizationRequirement : IAuthorizationRequirement
+    {
+    }
+}

--- a/app/SearchApi/SearchRequest.Adaptor/Auth/DynadapterTokenHandler.cs
+++ b/app/SearchApi/SearchRequest.Adaptor/Auth/DynadapterTokenHandler.cs
@@ -1,0 +1,87 @@
+using IdentityModel.Client;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace SearchRequestAdaptor.Auth
+{
+    public class DynadapterTokenHandler : DelegatingHandler
+    {
+        private const string CacheKey = "dynadapter_access_token";
+
+        private readonly IHttpClientFactory _httpClientFactory;
+        private readonly IMemoryCache _cache;
+        private readonly IConfiguration _configuration;
+        private readonly ILogger<DynadapterTokenHandler> _logger;
+
+        public DynadapterTokenHandler(
+            IHttpClientFactory httpClientFactory,
+            IMemoryCache cache,
+            IConfiguration configuration,
+            ILogger<DynadapterTokenHandler> logger)
+        {
+            _httpClientFactory = httpClientFactory;
+            _cache = cache;
+            _configuration = configuration;
+            _logger = logger;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            var token = await GetTokenAsync(cancellationToken);
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            return await base.SendAsync(request, cancellationToken);
+        }
+
+        private async Task<string> GetTokenAsync(CancellationToken cancellationToken)
+        {
+            if (_cache.TryGetValue(CacheKey, out string cachedToken) && !string.IsNullOrWhiteSpace(cachedToken))
+            {
+                return cachedToken;
+            }
+
+            var tokenUrl = _configuration["auth:dynadapter:tokenUrl"];
+            var clientId = _configuration["auth:dynadapter:clientId"];
+            var clientSecret = _configuration["auth:dynadapter:clientSecret"];
+
+            if (string.IsNullOrWhiteSpace(tokenUrl) || string.IsNullOrWhiteSpace(clientId) || string.IsNullOrWhiteSpace(clientSecret))
+            {
+                throw new InvalidOperationException("Dynadapter token configuration is incomplete. Set auth:dynadapter:tokenUrl, auth:dynadapter:clientId, and auth:dynadapter:clientSecret.");
+            }
+
+            using var httpClient = _httpClientFactory.CreateClient("dynadapter_token");
+            var response = await httpClient.RequestClientCredentialsTokenAsync(
+                new ClientCredentialsTokenRequest
+                {
+                    Address = tokenUrl,
+                    ClientId = clientId,
+                    ClientSecret = clientSecret,
+                },
+                cancellationToken
+            );
+
+            if (response.IsError)
+            {
+                _logger.LogError(
+                    "Dynadapter token acquisition failed: {Error} - {Description}",
+                    response.Error,
+                    response.ErrorDescription);
+
+                throw new InvalidOperationException(
+                    $"Dynadapter token acquisition failed: {response.Error} - {response.ErrorDescription}");
+            }
+
+            var expiresIn = response.ExpiresIn > 60 ? response.ExpiresIn - 60 : response.ExpiresIn;
+            _cache.Set(CacheKey, response.AccessToken, TimeSpan.FromSeconds(expiresIn));
+
+            return response.AccessToken;
+        }
+    }
+}

--- a/app/SearchApi/SearchRequest.Adaptor/Auth/DynadapterTokenHandler.cs
+++ b/app/SearchApi/SearchRequest.Adaptor/Auth/DynadapterTokenHandler.cs
@@ -10,6 +10,10 @@ using System.Threading.Tasks;
 
 namespace SearchRequestAdaptor.Auth
 {
+    /// <summary>
+    /// HTTP message handler for outbound requests to dynadapter.
+    /// Toggles between JWT bearer token (when enabled) and X-ApiKey header (when disabled).
+    /// </summary>
     public class DynadapterTokenHandler : DelegatingHandler
     {
         private const string CacheKey = "dynadapter_access_token";
@@ -35,8 +39,27 @@ namespace SearchRequestAdaptor.Auth
             HttpRequestMessage request,
             CancellationToken cancellationToken)
         {
-            var token = await GetTokenAsync(cancellationToken);
-            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+            var jwtEnabled = _configuration.GetValue<bool>("auth:dynadapter:enabled", defaultValue: false);
+
+            if (jwtEnabled)
+            {
+                var token = await GetTokenAsync(cancellationToken);
+                if (!string.IsNullOrEmpty(token))
+                {
+                    request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+                    _logger.LogDebug("Request sent with JWT bearer token");
+                }
+            }
+            else
+            {
+                var apiKey = _configuration["SearchRequestAdaptor:ApiKeyForDynadaptor"];
+                if (!string.IsNullOrEmpty(apiKey))
+                {
+                    request.Headers.Add("X-ApiKey", apiKey);
+                    _logger.LogDebug("Request sent with X-ApiKey header (JWT disabled)");
+                }
+            }
+
             return await base.SendAsync(request, cancellationToken);
         }
 
@@ -53,35 +76,41 @@ namespace SearchRequestAdaptor.Auth
 
             if (string.IsNullOrWhiteSpace(tokenUrl) || string.IsNullOrWhiteSpace(clientId) || string.IsNullOrWhiteSpace(clientSecret))
             {
-                throw new InvalidOperationException("Dynadapter token configuration is incomplete. Set auth:dynadapter:tokenUrl, auth:dynadapter:clientId, and auth:dynadapter:clientSecret.");
+                _logger.LogWarning("Dynadapter token configuration incomplete. Proceeding without JWT token.");
+                return string.Empty;
             }
 
-            using var httpClient = _httpClientFactory.CreateClient("dynadapter_token");
-            var response = await httpClient.RequestClientCredentialsTokenAsync(
-                new ClientCredentialsTokenRequest
-                {
-                    Address = tokenUrl,
-                    ClientId = clientId,
-                    ClientSecret = clientSecret,
-                },
-                cancellationToken
-            );
-
-            if (response.IsError)
+            try
             {
-                _logger.LogError(
-                    "Dynadapter token acquisition failed: {Error} - {Description}",
-                    response.Error,
-                    response.ErrorDescription);
+                using var httpClient = _httpClientFactory.CreateClient("dynadapter_token");
+                var response = await httpClient.RequestClientCredentialsTokenAsync(
+                    new ClientCredentialsTokenRequest
+                    {
+                        Address = tokenUrl,
+                        ClientId = clientId,
+                        ClientSecret = clientSecret,
+                    },
+                    cancellationToken);
 
-                throw new InvalidOperationException(
-                    $"Dynadapter token acquisition failed: {response.Error} - {response.ErrorDescription}");
+                if (response.IsError)
+                {
+                    _logger.LogError(
+                        "Dynadapter token acquisition failed: {Error} - {Description}",
+                        response.Error,
+                        response.ErrorDescription);
+                    return string.Empty;
+                }
+
+                var expiresIn = response.ExpiresIn > 60 ? response.ExpiresIn - 60 : response.ExpiresIn;
+                _cache.Set(CacheKey, response.AccessToken, TimeSpan.FromSeconds(expiresIn));
+
+                return response.AccessToken;
             }
-
-            var expiresIn = response.ExpiresIn > 60 ? response.ExpiresIn - 60 : response.ExpiresIn;
-            _cache.Set(CacheKey, response.AccessToken, TimeSpan.FromSeconds(expiresIn));
-
-            return response.AccessToken;
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "Exception during token acquisition for dynadapter");
+                return string.Empty;
+            }
         }
     }
 }

--- a/app/SearchApi/SearchRequest.Adaptor/Notifier/NotificationController.cs
+++ b/app/SearchApi/SearchRequest.Adaptor/Notifier/NotificationController.cs
@@ -1,4 +1,5 @@
 ﻿using BcGov.Fams3.SearchApi.Contracts.SearchRequest;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -14,6 +15,7 @@ namespace SearchRequest.Adaptor.Notifier
 {
     [Route("api/[controller]")]
     [ApiController]
+    [Authorize]
     public class NotificationController : ControllerBase
     {
         private readonly ILogger<NotificationController> _logger;

--- a/app/SearchApi/SearchRequest.Adaptor/Notifier/SearchRequestNotifier.cs
+++ b/app/SearchApi/SearchRequest.Adaptor/Notifier/SearchRequestNotifier.cs
@@ -19,7 +19,7 @@ namespace SearchRequestAdaptor.Notifier
 {
     public interface ISearchRequestNotifier<T>
     {
-        Task NotifySearchRequestEventAsync(string requestId, T searchRequestEvent, CancellationToken cancellationToken, int retryTimes=0, int maxRetryTimes=0);
+        Task NotifySearchRequestEventAsync(string requestId, T searchRequestEvent, CancellationToken cancellationToken, int retryTimes = 0, int maxRetryTimes = 0);
     }
 
     public class WebHookSearchRequestNotifier : ISearchRequestNotifier<SearchRequestEvent>
@@ -41,9 +41,9 @@ namespace SearchRequestAdaptor.Notifier
         }
 
         public async Task NotifySearchRequestEventAsync(string requestId, SearchRequestEvent searchRequestEvent,
-           CancellationToken cancellationToken, int retryTimes=0, int maxRetryTimes=0)
+           CancellationToken cancellationToken, int retryTimes = 0, int maxRetryTimes = 0)
         {
-            if(searchRequestEvent is SearchRequestOrdered)
+            if (searchRequestEvent is SearchRequestOrdered)
             {
                 await NotifySearchRequestOrderedEvent(requestId, (SearchRequestOrdered)searchRequestEvent, cancellationToken, retryTimes, maxRetryTimes);
             }
@@ -55,7 +55,7 @@ namespace SearchRequestAdaptor.Notifier
         }
 
         private async Task NotifySearchRequestOrderedEvent(
-            string requestId, 
+            string requestId,
             SearchRequestOrdered searchRequestOrdered,
             CancellationToken cancellationToken,
             int retryTimes,
@@ -101,13 +101,11 @@ namespace SearchRequestAdaptor.Notifier
                         System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json");
                     request.Headers.Accept.Add(
                         System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
-                    request.Headers.Add("X-ApiKey", _searchRequestOptions.ApiKeyForDynadaptor);
-
                     var response = await _httpClient.SendAsync(request, cancellationToken);
 
                     if (!response.IsSuccessStatusCode)
                     {
-                        if (response.StatusCode == System.Net.HttpStatusCode.InternalServerError || response.StatusCode==System.Net.HttpStatusCode.GatewayTimeout)
+                        if (response.StatusCode == System.Net.HttpStatusCode.InternalServerError || response.StatusCode == System.Net.HttpStatusCode.GatewayTimeout)
                         {
                             string reason = await response.Content.ReadAsStringAsync();
                             _logger.LogError(
@@ -140,7 +138,7 @@ namespace SearchRequestAdaptor.Notifier
 
                     //for the new action, we changed from Dynamics push the notification to here, openshift publish notification once sr is created.
                     //for the update action, fmep needs notified and notification from dynamics.
-                    if(saved.Action == RequestAction.NEW) 
+                    if (saved.Action == RequestAction.NEW)
                     {
                         _logger.LogInformation("create sr get success, publish accepted notification");
                         var notifyEvent = new SearchRequestNotificationEvent
@@ -148,7 +146,7 @@ namespace SearchRequestAdaptor.Notifier
                             ProviderProfile = saved.ProviderProfile,
                             NotificationType = NotificationType.RequestSaved,
                             RequestId = saved.RequestId,
-                            SearchRequestKey = saved.SearchRequestKey, 
+                            SearchRequestKey = saved.SearchRequestKey,
                             QueuePosition = saved.QueuePosition,
                             Message = $"Activity RequestSaved occured. ",
                             TimeStamp = DateTime.Now,
@@ -160,7 +158,7 @@ namespace SearchRequestAdaptor.Notifier
                     }
 
                     if (saved.Action == RequestAction.UPDATE)
-                    {                       
+                    {
                         _logger.LogInformation($"publish SearchRequestSaved");
                         await _searchRequestEventPublisher.PublishSearchRequestSaved(saved);
                         _logger.LogInformation("update sr get success, publish accepted notification");
@@ -237,7 +235,6 @@ namespace SearchRequestAdaptor.Notifier
                         System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json");
                     request.Headers.Accept.Add(
                         System.Net.Http.Headers.MediaTypeWithQualityHeaderValue.Parse("application/json"));
-                    request.Headers.Add("X-ApiKey", _searchRequestOptions.ApiKeyForDynadaptor);
                     request.Content = content;
 
                     _logger.LogDebug("Posting notification to webhook: {Endpoint}", endpoint);
@@ -259,7 +256,7 @@ namespace SearchRequestAdaptor.Notifier
                             response.StatusCode,
                             errorBody);
 
-                        if (response.StatusCode != System.Net.HttpStatusCode.InternalServerError 
+                        if (response.StatusCode != System.Net.HttpStatusCode.InternalServerError
                             && response.StatusCode != System.Net.HttpStatusCode.BadRequest)
                         {
                             throw new Exception($"Message Failed {response.StatusCode}, {errorBody}");

--- a/app/SearchApi/SearchRequest.Adaptor/Notifier/ServiceCollectionExtensions.cs
+++ b/app/SearchApi/SearchRequest.Adaptor/Notifier/ServiceCollectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using BcGov.Fams3.SearchApi.Contracts.SearchRequest;
 using Microsoft.Extensions.DependencyInjection;
+using SearchRequestAdaptor.Auth;
 
 namespace SearchRequestAdaptor.Notifier
 {
@@ -7,7 +8,11 @@ namespace SearchRequestAdaptor.Notifier
     {
         public static void AddWebHooks(this IServiceCollection services)
         {
-            services.AddHttpClient<ISearchRequestNotifier<SearchRequestEvent>, WebHookSearchRequestNotifier>();
+            services.AddMemoryCache();
+            services.AddTransient<DynadapterTokenHandler>();
+            services.AddHttpClient("dynadapter_token");
+            services.AddHttpClient<ISearchRequestNotifier<SearchRequestEvent>, WebHookSearchRequestNotifier>()
+                .AddHttpMessageHandler<DynadapterTokenHandler>();
         }
     }
 }

--- a/app/SearchApi/SearchRequest.Adaptor/SearchRequest.Adaptor.csproj
+++ b/app/SearchApi/SearchRequest.Adaptor/SearchRequest.Adaptor.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Jaeger" Version="1.0.3" />
     <PackageReference Include="MassTransit.AspNetCore" Version="6.2.3" />
     <PackageReference Include="MassTransit.RabbitMQ" Version="6.2.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.3" />
     <PackageReference Include="NSwag.AspNetCore" Version="13.6.2" />
     <PackageReference Include="OpenTracing" Version="0.12.1" />

--- a/app/SearchApi/SearchRequest.Adaptor/SearchRequest.Adaptor.csproj
+++ b/app/SearchApi/SearchRequest.Adaptor/SearchRequest.Adaptor.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="AspNetCore.HealthChecks.Rabbitmq" Version="3.1.4" />
     <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="8.0.1" />
+    <PackageReference Include="IdentityModel" Version="7.0.0" />
     <PackageReference Include="Jaeger" Version="1.0.3" />
     <PackageReference Include="MassTransit.AspNetCore" Version="6.2.3" />
     <PackageReference Include="MassTransit.RabbitMQ" Version="6.2.3" />

--- a/app/SearchApi/SearchRequest.Adaptor/SearchRequest.Adaptor.csproj
+++ b/app/SearchApi/SearchRequest.Adaptor/SearchRequest.Adaptor.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
+    <UserSecretsId>6e000e79-c3fa-4b21-a2c3-6af1e4e49f3d</UserSecretsId>
   </PropertyGroup>
 
   <ItemGroup>

--- a/app/SearchApi/SearchRequest.Adaptor/Startup.cs
+++ b/app/SearchApi/SearchRequest.Adaptor/Startup.cs
@@ -6,6 +6,8 @@ using FluentValidation;
 using Jaeger;
 using Jaeger.Samplers;
 using MassTransit;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Diagnostics.HealthChecks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
@@ -13,18 +15,22 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.Tokens;
 using NSwag;
 using HealthChecks.UI.Client;
 using OpenTracing;
 using OpenTracing.Util;
 using SearchRequest.Adaptor.Notifier.Models;
 using SearchRequest.Adaptor.Notifier.Models.Validation;
+using SearchRequestAdaptor.Auth;
 using SearchRequestAdaptor.Configuration;
 using SearchRequestAdaptor.Consumer;
 using SearchRequestAdaptor.Notifier;
 using SearchRequestAdaptor.Publisher;
+using Serilog;
 using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Net.Http.Headers;
 using GreenPipes;
@@ -60,6 +66,7 @@ namespace SearchRequestAdaptor
             this.ConfigureServiceBus(services);
             ConfigureOpenApi(services);
             ConfigureOpenTracing(services);
+            ConfigureAuthentication(services);
 
 
         }
@@ -112,6 +119,8 @@ namespace SearchRequestAdaptor
                 await next();
             });
             app.UseRouting();
+            app.UseAuthentication();
+            app.UseAuthorization();
             app.UseOpenApi();
             app.UseEndpoints(endpoints =>
             {
@@ -123,6 +132,47 @@ namespace SearchRequestAdaptor
                     ResponseWriter = UIResponseWriter.WriteHealthCheckUIResponse
                 });
                 endpoints.MapControllers();
+            });
+        }
+
+        private void ConfigureAuthentication(IServiceCollection services)
+        {
+            services.AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+                .AddJwtBearer(options =>
+                {
+                    options.Authority = Configuration["auth:jwt:authority"];
+                    options.Audience = Configuration["auth:jwt:audience"];
+                    options.TokenValidationParameters = new TokenValidationParameters
+                    {
+                        ValidateIssuerSigningKey = true,
+                    };
+                    options.Events = new JwtBearerEvents
+                    {
+                        OnTokenValidated = context =>
+                        {
+                            var sub = context.Principal?.FindFirst("sub")?.Value ?? "unknown";
+                            Log.Information("JWT token validated for subject {Subject}", sub);
+                            return Task.CompletedTask;
+                        },
+                        OnAuthenticationFailed = context =>
+                        {
+                            Log.Warning("JWT authentication failed: {Error}", context.Exception.Message);
+                            return Task.CompletedTask;
+                        }
+                    };
+                    options.Validate();
+                });
+
+            services.AddSingleton<IAuthorizationHandler, ConditionalAuthorizationHandler>();
+
+            services.AddAuthorization(options =>
+            {
+                var conditionalPolicy = new AuthorizationPolicyBuilder()
+                    .AddRequirements(new ConditionalAuthorizationRequirement())
+                    .Build();
+
+                options.DefaultPolicy = conditionalPolicy;
+                options.FallbackPolicy = conditionalPolicy;
             });
         }
 

--- a/app/SearchApi/SearchRequest.Adaptor/appsettings.json
+++ b/app/SearchApi/SearchRequest.Adaptor/appsettings.json
@@ -39,8 +39,14 @@
         "Name": "DynAdapter",
         "Uri": "http://localhost:9000/AgencyRequest"
       }
-    ],
-    "ApiKeyForDynadaptor": "6f975845-91a7-4038-830a-eb222b2559fe"
+    ]
+  },
+  "auth": {
+    "dynadapter": {
+      "enabled": false,
+      "tokenUrl": "https://keycloak:8080/auth/realms/fams/protocol/openid-connect/token",
+      "clientId": "search-request-adaptor",
+      "clientSecret": "replace-me"
+    }
   }
-
 }


### PR DESCRIPTION
This pull request introduces a feature-flag-driven JWT authentication and authorization system for the DynamicsAdapter web application, replacing the prior API key-based approach. The system allows toggling authentication requirements via configuration, and adds support for secure outbound API calls using either JWT tokens or API keys, depending on feature flags. The changes also include updates to dependency injection, controller protection, and configuration files to support these new authentication mechanisms.

**Authentication and Authorization Overhaul:**

- Added a conditional JWT authentication and authorization system:
  - Introduced `ConditionalAuthorizationHandler` and `ConditionalAuthorizationRequirement` to enforce JWT authentication based on the `auth:jwt:enabled` configuration flag. When disabled, all requests are allowed; when enabled, JWT is required. [[1]](diffhunk://#diff-75190a7bfa69bf3116f0929e6f9107eff382a12efb6d03e0ffc30093ed66eda1R1-R44) [[2]](diffhunk://#diff-6952d4f66e25fc217b781da029d07215a80122aed93e25b94841c281798ea733R1-R8)
  - Updated `Startup.cs` to configure JWT authentication, register the conditional authorization handler, and set the default and fallback authorization policies to use this handler. [[1]](diffhunk://#diff-c820e884c616d0978faad9fa02a7ce94dcfdb9d79c1e699bbbf230da2250df79R92) [[2]](diffhunk://#diff-c820e884c616d0978faad9fa02a7ce94dcfdb9d79c1e699bbbf230da2250df79R103-R146)
  - Added JWT authentication and authorization middleware to the application pipeline and removed the old API key middleware.
  - Applied the `[Authorize]` attribute to all main API controllers to enforce the new authorization policy. [[1]](diffhunk://#diff-86a99fedbb05b8128b566e19794bf0c52aff1208af5a1d6ca5c9b9997731f0e6R30) [[2]](diffhunk://#diff-e26330a2a03eedfc50a61ab5091b6531f0f79db55008879e1e128c4f16bb9e06R20) [[3]](diffhunk://#diff-ea1feb4df08dd50508eafe011f5627eaa28dacd47507f56185412f109f5aee58R20)

**Outbound API Security:**

- Implemented feature-flag-driven outbound API authentication handlers:
  - Added `RequestApiTokenHandler` for outbound requests from DynamicsAdapter to request-api, switching between JWT bearer tokens and API keys based on configuration.
  - Registered the handler in DI and attached it to the `AgencyNotificationWebhook` HTTP client.
  - Added `DynadapterTokenHandler` in SearchApi for secure outbound requests to dynadapter, also supporting JWT or API key based on configuration.

**Configuration and Dependency Updates:**

- Updated `appsettings.json` to support new authentication configuration sections, including JWT and API key settings for both inbound and outbound authentication.
- Added new NuGet package dependencies for JWT and token management (`IdentityModel`, `Microsoft.AspNetCore.Authentication.JwtBearer`).

**Minor Improvements:**

- Allowed anonymous access to the health check endpoint to prevent authentication requirements from interfering with health monitoring.
- Added necessary `using` statements for new authentication and authorization features in relevant files. [[1]](diffhunk://#diff-86a99fedbb05b8128b566e19794bf0c52aff1208af5a1d6ca5c9b9997731f0e6R13) [[2]](diffhunk://#diff-e26330a2a03eedfc50a61ab5091b6531f0f79db55008879e1e128c4f16bb9e06R6) [[3]](diffhunk://#diff-ea1feb4df08dd50508eafe011f5627eaa28dacd47507f56185412f109f5aee58R5) [[4]](diffhunk://#diff-c820e884c616d0978faad9fa02a7ce94dcfdb9d79c1e699bbbf230da2250df79R14-R16) [[5]](diffhunk://#diff-c820e884c616d0978faad9fa02a7ce94dcfdb9d79c1e699bbbf230da2250df79R49)

These changes collectively modernize and secure the application's authentication model, while providing flexibility for different deployment scenarios.